### PR TITLE
로그아웃 기능 fix

### DIFF
--- a/user-service/src/main/java/com/hermes/userservice/controller/AuthController.java
+++ b/user-service/src/main/java/com/hermes/userservice/controller/AuthController.java
@@ -25,6 +25,7 @@ import java.time.Instant;
 import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.security.core.Authentication;
 
 @Slf4j
 @RestController
@@ -47,24 +48,32 @@ public class AuthController {
 
     @PostMapping("/logout")
     public ResponseEntity<ApiResponse<Map<String, String>>> logout(
-            @AuthenticationPrincipal UserPrincipal user,
+            Authentication authentication,
             @RequestHeader(value = HttpHeaders.AUTHORIZATION, required = false) String authHeader) {
         
+        UserPrincipal user = null;
+        // authentication.getPrincipal() 대신 authentication.getDetails()를 사용합니다.
+        if (authentication != null && authentication.getDetails() instanceof UserPrincipal) {
+            user = (UserPrincipal) authentication.getDetails();
+        }
+
+        // 인증 확인
         if (user == null) {
-            throw new IllegalArgumentException("인증된 사용자 정보를 찾을 수 없습니다.");
+            log.error("❌ [Auth Controller] /logout 요청 실패 - 인증된 사용자 정보를 찾을 수 없음 (UserPrincipal 추출 실패)");
+            throw new IllegalArgumentException("인증된 사용자 정보를 찾을 수 없습니다. 유효한 JWT 토큰을 포함해주세요.");
         }
         
         Long userId = user.getUserId();
         String email = user.getEmail();
         
-        log.info(" [Auth Controller] /logout 요청 - userId: {}, email: {}", userId, email);
+        log.info("✅ [Auth Controller] /logout 요청 - userId: {}, email: {}", userId, email);
 
         String accessToken = null;
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
             accessToken = authHeader.substring(7); // "Bearer " 제거
-            log.info(" [Auth Controller] Access Token 추출 완료 - userId: {}", userId);
+            log.info("✅ [Auth Controller] Access Token 추출 완료 - userId: {}", userId);
         } else {
-            log.warn("⚠ [Auth Controller] Authorization 헤더가 없거나 형식이 잘못됨 - userId: {}", userId);
+            log.warn("⚠️ [Auth Controller] Authorization 헤더가 없거나 형식이 잘못됨 - userId: {}", userId);
         }
 
         // RefreshToken을 DB에서 가져오기
@@ -79,6 +88,7 @@ public class AuthController {
         result.put("email", email != null ? email : "unknown");
         result.put("message", "로그아웃이 성공적으로 처리되었습니다. 모든 토큰이 삭제되었습니다.");
 
+        log.info("✅ [Auth Controller] 로그아웃 성공 - userId: {}", userId);
         return ResponseEntity.ok(ApiResponse.success("로그아웃이 성공적으로 처리되었습니다.", result));
     }
 

--- a/user-service/src/main/java/com/hermes/userservice/controller/AuthController.java
+++ b/user-service/src/main/java/com/hermes/userservice/controller/AuthController.java
@@ -94,22 +94,36 @@ public class AuthController {
 
     @PostMapping("/refresh")
     public ResponseEntity<ApiResponse<TokenResponse>> refreshToken(
-            @AuthenticationPrincipal UserPrincipal user,
+            Authentication authentication,
             @RequestBody RefreshRequest request) {
 
-        log.info(" [Auth Controller] /refresh 요청 - userId: {}", user.getUserId());
+        UserPrincipal user = null;
+        // authentication.getPrincipal() 대신 authentication.getDetails()를 사용합니다.
+        if (authentication != null && authentication.getDetails() instanceof UserPrincipal) {
+            user = (UserPrincipal) authentication.getDetails();
+        }
+
+        // 인증 확인
+        if (user == null) {
+            log.error("❌ [Auth Controller] /refresh 요청 실패 - 인증된 사용자 정보를 찾을 수 없음 (UserPrincipal 추출 실패)");
+            throw new IllegalArgumentException("인증된 사용자 정보를 찾을 수 없습니다. 유효한 JWT 토큰을 포함해주세요.");
+        }
 
         Long userId = user.getUserId();
         String email = user.getEmail();
+
+        log.info("✅ [Auth Controller] /refresh 요청 - userId: {}", userId);
 
         RefreshToken saved = refreshTokenRepository.findByUserId(userId)
                 .orElseThrow(() -> new RuntimeException("RefreshToken not found"));
 
         if (!saved.getToken().equals(request.getRefreshToken())) {
+            log.warn("⚠️ [Auth Controller] 유효하지 않은 RefreshToken - userId: {}", userId);
             throw new RuntimeException("유효하지 않은 RefreshToken입니다.");
         }
 
         if (tokenBlacklistService.isTokenBlacklisted(request.getRefreshToken())) {
+            log.warn("⚠️ [Auth Controller] 로그아웃된 RefreshToken - userId: {}", userId);
             throw new RuntimeException("로그아웃된 Refresh Token입니다.");
         }
 
@@ -117,6 +131,7 @@ public class AuthController {
         Instant expiration = saved.getExpiration().atZone(ZoneId.systemDefault()).toInstant();
 
         if (expiration.isBefore(now)) {
+            log.warn("⚠️ [Auth Controller] 만료된 RefreshToken - userId: {}", userId);
             throw new RuntimeException("만료된 RefreshToken입니다.");
         }
 
@@ -126,7 +141,7 @@ public class AuthController {
         Role userRole = userEntity.getIsAdmin() ? Role.ADMIN : Role.USER;
         String newAccessToken = jwtTokenService.createAccessToken(email, userId, userRole, null);
 
-        log.info(" [Auth Controller] 토큰 갱신 성공: userId={}", userId);
+        log.info("✅ [Auth Controller] 토큰 갱신 성공: userId={}", userId);
         return ResponseEntity.ok(ApiResponse.success("토큰이 성공적으로 갱신되었습니다.",
                 new TokenResponse(newAccessToken, saved.getToken())));
     }

--- a/user-service/src/main/java/com/hermes/userservice/service/JwtTokenService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/JwtTokenService.java
@@ -15,6 +15,7 @@ import java.time.temporal.ChronoUnit;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import io.jsonwebtoken.io.Decoders;
 
 /**
  * JWT 토큰 생성 전용 서비스 (user-service에서만 사용)
@@ -86,7 +87,8 @@ public class JwtTokenService {
      * JWT 서명 키 생성
      */
     private SecretKey getSigningKey() {
-        byte[] keyBytes = jwtProperties.getSecret().getBytes(StandardCharsets.UTF_8);
+        // Base64 디코딩 후 사용
+        byte[] keyBytes = Decoders.BASE64.decode(jwtProperties.getSecret());
         return Keys.hmacShaKeyFor(keyBytes);
     }
 }


### PR DESCRIPTION
## 이슈 번호

close #72

## 작업 사항
1. JWT Secret Key 일관성 확보: user-service의 JWT 토큰 생성 시 Base64 디코딩을 사용하도록 JwtTokenService 수정하여 libs/auth-starter의 검증 방식과 일치.

2. 인증된 사용자 정보 추출 개선: AuthController의 logout 및 refreshToken 메소드에서 Authentication 객체의 details를 통해 UserPrincipal을 정확히 추출하도록 수정.

3. Refresh Token DB 삭제 로직 수정: UserService의 logout 메소드에서 userId로 Refresh Token을 찾아 삭제하도록 변경 및 @Transactional 적용.

## 스크린샷 (선택)


## 공유사항























