### PR TITLE
동료 근무 검색 기능 추가

### DIFF
--- a/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
@@ -13,6 +13,9 @@ public interface UserServiceClient {
     @GetMapping("/api/users/{userId}/simple")
     Map<String, Object> getUserById(@PathVariable("userId") Long userId);
     
+    @GetMapping("/api/users/{userId}")
+    Map<String, Object> getUserById(@PathVariable("userId") Long userId, @RequestHeader(value = "Authorization", required = false) String authorization);
+    
     @GetMapping("/api/users/count")
     Map<String, Object> getTotalEmployees();
 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/ColleagueScheduleResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/ColleagueScheduleResponseDto.java
@@ -1,0 +1,47 @@
+package com.hermes.attendanceservice.dto.workschedule;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ColleagueScheduleResponseDto {
+    private Long colleagueId;
+    private String colleagueName;
+    private String colleaguePosition;
+    private String colleagueDepartment;
+    private String colleagueAvatar;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private List<DailyScheduleDto> dailySchedules;
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class DailyScheduleDto {
+        private LocalDate date;
+        private String dayOfWeek; // "Mon", "Tue", etc.
+        private List<ScheduleEventDto> events;
+    }
+    
+    @Data
+    @Builder
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ScheduleEventDto {
+        private Long scheduleId;
+        private String title; // "근무", "휴게", "외근", "출장", "재택"
+        private LocalTime startTime;
+        private LocalTime endTime;
+        private String scheduleType; // WORK, BREAK, EXTERNAL_WORK, BUSINESS_TRIP, WORK_FROM_HOME
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/ColleagueScheduleResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/ColleagueScheduleResponseDto.java
@@ -39,7 +39,6 @@ public class ColleagueScheduleResponseDto {
     @AllArgsConstructor
     public static class ScheduleEventDto {
         private Long scheduleId;
-        private String title; // "근무", "휴게", "외근", "출장", "재택"
         private LocalTime startTime;
         private LocalTime endTime;
         private String scheduleType; // WORK, BREAK, EXTERNAL_WORK, BUSINESS_TRIP, WORK_FROM_HOME

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
@@ -983,32 +983,10 @@ public class WorkScheduleService {
     private ColleagueScheduleResponseDto.ScheduleEventDto convertToScheduleEventDto(Schedule schedule) {
         return ColleagueScheduleResponseDto.ScheduleEventDto.builder()
                 .scheduleId(schedule.getId())
-                .title(getScheduleTitle(schedule.getScheduleType()))
+                .title(schedule.getScheduleType().toString())
                 .startTime(schedule.getStartTime())
                 .endTime(schedule.getEndTime())
                 .scheduleType(schedule.getScheduleType().toString())
                 .build();
-    }
-    
-    /**
-     * 스케줄 타입에 따른 제목 반환
-     */
-    private String getScheduleTitle(ScheduleType scheduleType) {
-        switch (scheduleType) {
-            case WORK:
-                return "근무";
-            case OUT_OF_OFFICE:
-                return "외근";
-            case BUSINESS_TRIP:
-                return "출장";
-            case SICK_LEAVE:
-                return "병가";
-            case VACATION:
-                return "휴가";
-            case OVERTIME:
-                return "초과근무";
-            default:
-                return "기타";
-        }
     }
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
@@ -2,6 +2,7 @@ package com.hermes.attendanceservice.service.workschedule;
 
 import com.hermes.attendanceservice.client.UserServiceClient;
 import com.hermes.attendanceservice.dto.workschedule.AdjustWorkTimeRequestDto;
+import com.hermes.attendanceservice.dto.workschedule.ColleagueScheduleResponseDto;
 import com.hermes.attendanceservice.dto.workschedule.CreateScheduleRequestDto;
 import com.hermes.attendanceservice.dto.workschedule.ScheduleResponseDto;
 import com.hermes.attendanceservice.dto.workschedule.UpdateScheduleRequestDto;
@@ -905,5 +906,109 @@ public class WorkScheduleService {
                 .isHolidayFixed(responseDto.getIsHolidayFixed())
                 .isBreakFixed(responseDto.getIsBreakFixed())
                 .build();
+    }
+    
+    /**
+     * 동료 근무표 조회
+     */
+    public ColleagueScheduleResponseDto getColleagueSchedule(Long colleagueId, LocalDate startDate, LocalDate endDate) {
+        try {
+            // 1. 동료 정보 조회 (User Service에서)
+            Map<String, Object> colleagueInfo = userServiceClient.getUserById(colleagueId, null);
+            if (colleagueInfo == null) {
+                log.error("Colleague not found: {}", colleagueId);
+                return null;
+            }
+            
+            // 2. 동료의 스케줄 조회
+            List<Schedule> schedules = scheduleRepository.findByUserIdAndDateRange(colleagueId, "ACTIVE", startDate, endDate);
+            
+            // 3. 일별 스케줄로 그룹화
+            Map<LocalDate, List<Schedule>> schedulesByDate = schedules.stream()
+                    .collect(Collectors.groupingBy(Schedule::getStartDate));
+            
+            // 4. 응답 DTO 생성
+            List<ColleagueScheduleResponseDto.DailyScheduleDto> dailySchedules = new ArrayList<>();
+            
+            LocalDate currentDate = startDate;
+            while (!currentDate.isAfter(endDate)) {
+                List<Schedule> daySchedules = schedulesByDate.getOrDefault(currentDate, new ArrayList<>());
+                
+                List<ColleagueScheduleResponseDto.ScheduleEventDto> events = daySchedules.stream()
+                        .map(this::convertToScheduleEventDto)
+                        .collect(Collectors.toList());
+                
+                ColleagueScheduleResponseDto.DailyScheduleDto dailySchedule = ColleagueScheduleResponseDto.DailyScheduleDto.builder()
+                        .date(currentDate)
+                        .dayOfWeek(currentDate.getDayOfWeek().getDisplayName(java.time.format.TextStyle.SHORT, java.util.Locale.ENGLISH))
+                        .events(events)
+                        .build();
+                
+                dailySchedules.add(dailySchedule);
+                currentDate = currentDate.plusDays(1);
+            }
+            
+            // Map에서 필요한 정보 추출
+            String colleagueName = (String) colleagueInfo.get("name");
+            String colleaguePosition = "";
+            String colleagueDepartment = "";
+            String colleagueAvatar = (String) colleagueInfo.get("profileImageUrl");
+            
+            // position 정보 추출
+            if (colleagueInfo.get("position") != null) {
+                Map<String, Object> position = (Map<String, Object>) colleagueInfo.get("position");
+                colleaguePosition = (String) position.get("name");
+            }
+            
+            return ColleagueScheduleResponseDto.builder()
+                    .colleagueId(colleagueId)
+                    .colleagueName(colleagueName)
+                    .colleaguePosition(colleaguePosition)
+                    .colleagueDepartment(colleagueDepartment)
+                    .colleagueAvatar(colleagueAvatar)
+                    .startDate(startDate)
+                    .endDate(endDate)
+                    .dailySchedules(dailySchedules)
+                    .build();
+                    
+        } catch (Exception e) {
+            log.error("Error fetching colleague schedule for colleagueId: {} from {} to {}", colleagueId, startDate, endDate, e);
+            throw new RuntimeException("Failed to fetch colleague schedule", e);
+        }
+    }
+    
+    /**
+     * Schedule 엔티티를 ScheduleEventDto로 변환
+     */
+    private ColleagueScheduleResponseDto.ScheduleEventDto convertToScheduleEventDto(Schedule schedule) {
+        return ColleagueScheduleResponseDto.ScheduleEventDto.builder()
+                .scheduleId(schedule.getId())
+                .title(getScheduleTitle(schedule.getScheduleType()))
+                .startTime(schedule.getStartTime())
+                .endTime(schedule.getEndTime())
+                .scheduleType(schedule.getScheduleType().toString())
+                .build();
+    }
+    
+    /**
+     * 스케줄 타입에 따른 제목 반환
+     */
+    private String getScheduleTitle(ScheduleType scheduleType) {
+        switch (scheduleType) {
+            case WORK:
+                return "근무";
+            case OUT_OF_OFFICE:
+                return "외근";
+            case BUSINESS_TRIP:
+                return "출장";
+            case SICK_LEAVE:
+                return "병가";
+            case VACATION:
+                return "휴가";
+            case OVERTIME:
+                return "초과근무";
+            default:
+                return "기타";
+        }
     }
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
@@ -983,7 +983,6 @@ public class WorkScheduleService {
     private ColleagueScheduleResponseDto.ScheduleEventDto convertToScheduleEventDto(Schedule schedule) {
         return ColleagueScheduleResponseDto.ScheduleEventDto.builder()
                 .scheduleId(schedule.getId())
-                .title(schedule.getScheduleType().toString())
                 .startTime(schedule.getStartTime())
                 .endTime(schedule.getEndTime())
                 .scheduleType(schedule.getScheduleType().toString())


### PR DESCRIPTION
## 이슈 번호

close #102 

## 작업 사항
동료 근무 일정 조회 API 응답 DTO 구현

- ColleagueScheduleResponseDto 클래스 추가
- 동료 정보 (ID, 이름, 직책, 부서, 아바타) 포함
- 일정 조회 기간 (시작일, 종료일) 설정
- 일별 일정 정보 (날짜, 요일, 이벤트 목록) 구조화
- 근무 이벤트 정보 (일정ID, 제목, 시작/종료 시간, 일정 타입) 정의
- 근무 타입: WORK, BREAK, EXTERNAL_WORK, BUSINESS_TRIP, WORK_FROM_HOME 지원

## 스크린샷 (선택)


## 공유사항























