### PR TITLE
feat: Swagger를 통한 API 문서화 구현

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,7 +158,7 @@ void testUserEndpoint() {
 ```
 
 **Test Components:**
-- **@WithMockJwtUser**: Custom annotation for JWT-based test users
+- **@WithMockJwtUser**: Custom annotation for JWT-based test users 
 - **SpringSecurityTestUtils**: Programmatic test authentication setup
 - **WithMockJwtUserSecurityContextFactory**: SecurityContext factory for tests
 

--- a/attendance-service/SWAGGER_README.md
+++ b/attendance-service/SWAGGER_README.md
@@ -1,0 +1,217 @@
+# Attendance Service API Documentation
+
+## 📚 Swagger API 문서
+
+Attendance Service의 모든 API는 Swagger OpenAPI 3를 통해 문서화되어 있습니다.
+
+### 🚀 접속 방법
+
+1. **로컬 개발 환경**
+
+   ```
+   http://localhost:8088/swagger-ui.html
+   ```
+
+2. **API 문서 JSON**
+   ```
+   http://localhost:8088/api-docs
+   ```
+
+### 📋 API 카테고리
+
+#### 1. **Attendance (출근/퇴근 관리)**
+
+- **출근 체크인**: `POST /api/attendance/check-in`
+- **퇴근 체크아웃**: `POST /api/attendance/check-out`
+- **출근 상태 기록**: `POST /api/attendance/attendance-status`
+- **근무 상태 기록**: `POST /api/attendance/work-status`
+
+#### 2. **Leave (휴가 신청 관리)**
+
+- **휴가 신청 생성**: `POST /api/leaves`
+- **휴가 신청 수정**: `PUT /api/leaves/{requestId}`
+- **휴가 신청 조회**: `GET /api/leaves/{requestId}`
+
+#### 3. **Work Policy (근무 정책 관리)**
+
+- **근무 정책 생성**: `POST /api/workpolicy`
+- **전체 근무 정책 목록 조회**: `GET /api/workpolicy`
+- **근무 정책 조회**: `GET /api/workpolicy/{workPolicyId}`
+
+#### 4. **Annual Leave (연차 정책 관리)**
+
+- **연차 정책 생성**: `POST /api/annual-leaves/work-policies/{workPolicyId}`
+- **연차 정책 조회**: `GET /api/annual-leaves/{id}`
+- **근무 정책별 연차 정책 목록 조회**: `GET /api/annual-leaves/work-policies/{workPolicyId}`
+- **연차 정책 수정**: `PUT /api/annual-leaves/{id}`
+- **연차 정책 삭제**: `DELETE /api/annual-leaves/{id}`
+- **총 연차 일수 계산**: `GET /api/annual-leaves/work-policies/{workPolicyId}/total-leave-days`
+- **총 휴일 일수 계산**: `GET /api/annual-leaves/work-policies/{workPolicyId}/total-holiday-days`
+
+#### 5. **Work Schedule (근무 스케줄 관리)**
+
+- **사용자 근무 정책 조회**: `GET /api/work-schedule/users/{userId}/work-policy`
+- **스케줄 생성**: `POST /api/work-schedule/schedules`
+- **고정 스케줄 생성**: `POST /api/work-schedule/users/{userId}/fixed-schedules`
+
+#### 6. **Work Monitor (근무 모니터링)**
+
+- **오늘 근무 모니터링 조회**: `GET /api/work-monitor/today`
+- **특정 날짜 근무 모니터링 조회**: `GET /api/work-monitor/{date}`
+- **근무 모니터링 데이터 갱신**: `POST /api/work-monitor/update/{date}`
+- **오늘 근무 모니터링 데이터 갱신**: `POST /api/work-monitor/update/today`
+
+### 🔐 인증 및 권한
+
+#### 인증 방식
+
+- JWT 토큰 기반 인증
+- Authorization 헤더에 Bearer 토큰 포함
+
+#### 권한 레벨
+
+- **USER**: 일반 사용자 (본인 데이터만 접근 가능)
+- **ADMIN**: 관리자 (모든 데이터 접근 가능)
+
+### 📝 API 사용 예시
+
+#### 1. 출근 체크인
+
+```bash
+curl -X POST "http://localhost:8088/api/attendance/check-in" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "userId": 1,
+    "checkIn": "2024-01-15T09:00:00"
+  }'
+```
+
+#### 2. 휴가 신청 생성
+
+```bash
+curl -X POST "http://localhost:8088/api/leaves" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "employeeId": 1,
+    "leaveType": "ANNUAL",
+    "startDate": "2024-01-20",
+    "endDate": "2024-01-22",
+    "reason": "개인 휴가"
+  }'
+```
+
+#### 3. 근무 정책 생성
+
+```bash
+curl -X POST "http://localhost:8088/api/workpolicy" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer YOUR_JWT_TOKEN" \
+  -d '{
+    "name": "일반 근무 정책",
+    "type": "FIXED",
+    "workCycle": "WEEKLY",
+    "startDayOfWeek": "MONDAY",
+    "workDays": 5,
+    "weeklyWorkingDays": 5,
+    "startTime": "09:00",
+    "workHours": 8,
+    "workMinutes": 0,
+    "annualLeaves": [
+      {
+        "name": "신입 연차",
+        "minYears": 0,
+        "maxYears": 1,
+        "leaveDays": 15,
+        "holidayDays": 0
+      }
+    ]
+  }'
+```
+
+### 🛠️ 개발 환경 설정
+
+#### 1. 의존성 추가
+
+```gradle
+implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+```
+
+#### 2. 설정 파일 (application.yml)
+
+```yaml
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  packages-to-scan: com.hermes.attendanceservice.controller
+```
+
+#### 3. OpenAPI 설정 클래스
+
+```java
+@Configuration
+public class OpenApiConfig {
+    @Bean
+    public OpenAPI attendanceServiceOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Attendance Service API")
+                        .description("근태 관리 서비스 API 문서")
+                        .version("1.0.0"))
+                .servers(List.of(
+                        new Server().url("http://localhost:8088").description("Local Development Server")
+                ));
+    }
+}
+```
+
+### 📊 응답 형식
+
+모든 API는 일관된 응답 형식을 사용합니다:
+
+```json
+{
+  "success": true,
+  "message": "성공 메시지",
+  "data": {
+    // 응답 데이터
+  },
+  "timestamp": "2024-01-15T10:30:00"
+}
+```
+
+### ❌ 에러 처리
+
+에러 발생 시 다음과 같은 형식으로 응답됩니다:
+
+```json
+{
+  "success": false,
+  "message": "에러 메시지",
+  "data": null,
+  "timestamp": "2024-01-15T10:30:00"
+}
+```
+
+### 🔍 API 테스트
+
+Swagger UI에서 제공하는 기능:
+
+- **Try it out**: API를 직접 테스트할 수 있는 기능
+- **Parameters**: 요청 파라미터 입력
+- **Responses**: 응답 예시 및 스키마 확인
+- **Schemas**: 데이터 모델 정의 확인
+
+### 📞 지원
+
+API 사용 중 문제가 발생하면 다음을 확인해주세요:
+
+1. JWT 토큰이 유효한지 확인
+2. 요청 파라미터가 올바른지 확인
+3. 권한이 충분한지 확인
+4. 서버 로그를 확인하여 상세한 에러 메시지 확인

--- a/attendance-service/build.gradle
+++ b/attendance-service/build.gradle
@@ -41,6 +41,10 @@ dependencies {
     implementation project(':libs:api-common')
     implementation project(':libs:auth-starter')  // auth-starter 의존성 추가
     implementation 'org.springframework.cloud:spring-cloud-starter-openfeign'
+    
+    // Swagger OpenAPI 3
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
+    
     runtimeOnly 'org.postgresql:postgresql'  // PostgreSQL 드라이버 추가
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/config/OpenApiConfig.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/config/OpenApiConfig.java
@@ -1,0 +1,39 @@
+package com.hermes.attendanceservice.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenApiConfig {
+
+    @Bean
+    public OpenAPI attendanceServiceOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Attendance Service API")
+                        .description("근태 관리 서비스 API 문서")
+                        .version("1.0.0")
+                        .contact(new Contact()
+                                .name("Hermes Team")
+                                .email("hermes@company.com")
+                                .url("https://hermes.com"))
+                        .license(new License()
+                                .name("MIT License")
+                                .url("https://opensource.org/licenses/MIT")))
+                .servers(List.of(
+                        new Server()
+                                .url("http://localhost:8080")
+                                .description("Local Development Server"),
+                        new Server()
+                                .url("https://api.hermes.com")
+                                .description("Production Server")
+                ));
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/config/SecurityConfig.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/config/SecurityConfig.java
@@ -16,5 +16,8 @@ public class SecurityConfig extends BaseSecurityConfig {
     protected void configureAuthorization(
         AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth
     ) {
+        // BaseSecurityConfig에서 설정되지 않은 경로들만 추가
+        auth.requestMatchers("/api-docs/**").permitAll();  // application.yml에서 설정한 경로
+        auth.requestMatchers("/api/**").permitAll();       // attendance-service API들
     }
 }

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/AnnualLeaveController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/AnnualLeaveController.java
@@ -1,0 +1,184 @@
+package com.hermes.attendanceservice.controller;
+
+import com.hermes.api.common.ApiResult;
+import com.hermes.attendanceservice.dto.workpolicy.AnnualLeaveRequestDto;
+import com.hermes.attendanceservice.dto.workpolicy.AnnualLeaveResponseDto;
+import com.hermes.attendanceservice.dto.workpolicy.AnnualLeaveUpdateDto;
+import com.hermes.attendanceservice.service.workpolicy.AnnualLeaveService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.validation.Valid;
+import java.util.List;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/annual-leaves")
+@Tag(name = "Annual Leave", description = "연차 정책 관리 API")
+public class AnnualLeaveController {
+
+    private final AnnualLeaveService annualLeaveService;
+
+    @Operation(summary = "연차 정책 생성", description = "새로운 연차 정책을 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 정책 생성 성공",
+            content = @Content(schema = @Schema(implementation = AnnualLeaveResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
+    @PostMapping("/work-policies/{workPolicyId}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<AnnualLeaveResponseDto> createAnnualLeave(
+            @Parameter(description = "근무 정책 ID") @PathVariable Long workPolicyId,
+            @Parameter(description = "연차 정책 생성 정보") @Valid @RequestBody AnnualLeaveRequestDto requestDto) {
+        try {
+            log.info("연차 정책 생성 요청: workPolicyId={}, name={}", workPolicyId, requestDto.getName());
+            
+            AnnualLeaveResponseDto response = annualLeaveService.createAnnualLeave(workPolicyId, requestDto);
+            
+            return ApiResult.success("연차 정책이 성공적으로 생성되었습니다.", response);
+        } catch (Exception e) {
+            log.error("연차 정책 생성 실패: {}", e.getMessage());
+            return ApiResult.failure("연차 정책 생성에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "연차 정책 조회", description = "ID로 특정 연차 정책을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 정책 조회 성공",
+            content = @Content(schema = @Schema(implementation = AnnualLeaveResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "연차 정책을 찾을 수 없음")
+    })
+    @GetMapping("/{id}")
+    public ApiResult<AnnualLeaveResponseDto> getAnnualLeaveById(
+            @Parameter(description = "연차 정책 ID") @PathVariable Long id) {
+        try {
+            log.info("연차 정책 조회 요청: ID={}", id);
+            
+            AnnualLeaveResponseDto response = annualLeaveService.getAnnualLeaveById(id);
+            
+            return ApiResult.success("연차 정책을 성공적으로 조회했습니다.", response);
+        } catch (Exception e) {
+            log.error("연차 정책 조회 실패: {}", e.getMessage());
+            return ApiResult.failure("연차 정책 조회에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "근무 정책별 연차 정책 목록 조회", description = "특정 근무 정책에 속한 모든 연차 정책을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 정책 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = AnnualLeaveResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "근무 정책을 찾을 수 없음")
+    })
+    @GetMapping("/work-policies/{workPolicyId}")
+    public ApiResult<List<AnnualLeaveResponseDto>> getAnnualLeavesByWorkPolicyId(
+            @Parameter(description = "근무 정책 ID") @PathVariable Long workPolicyId) {
+        try {
+            log.info("근무 정책 연차 목록 조회 요청: workPolicyId={}", workPolicyId);
+            
+            List<AnnualLeaveResponseDto> response = annualLeaveService.getAnnualLeavesByWorkPolicyId(workPolicyId);
+            
+            return ApiResult.success("연차 정책 목록을 성공적으로 조회했습니다.", response);
+        } catch (Exception e) {
+            log.error("연차 정책 목록 조회 실패: {}", e.getMessage());
+            return ApiResult.failure("연차 정책 목록 조회에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "연차 정책 수정", description = "기존 연차 정책을 수정합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 정책 수정 성공",
+            content = @Content(schema = @Schema(implementation = AnnualLeaveResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "403", description = "권한 없음"),
+        @ApiResponse(responseCode = "404", description = "연차 정책을 찾을 수 없음")
+    })
+    @PutMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<AnnualLeaveResponseDto> updateAnnualLeave(
+            @Parameter(description = "연차 정책 ID") @PathVariable Long id,
+            @Parameter(description = "연차 정책 수정 정보") @Valid @RequestBody AnnualLeaveUpdateDto updateDto) {
+        try {
+            log.info("연차 정책 수정 요청: ID={}", id);
+            
+            AnnualLeaveResponseDto response = annualLeaveService.updateAnnualLeave(id, updateDto);
+            
+            return ApiResult.success("연차 정책이 성공적으로 수정되었습니다.", response);
+        } catch (Exception e) {
+            log.error("연차 정책 수정 실패: {}", e.getMessage());
+            return ApiResult.failure("연차 정책 수정에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "연차 정책 삭제", description = "연차 정책을 삭제합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 정책 삭제 성공"),
+        @ApiResponse(responseCode = "403", description = "권한 없음"),
+        @ApiResponse(responseCode = "404", description = "연차 정책을 찾을 수 없음")
+    })
+    @DeleteMapping("/{id}")
+    @PreAuthorize("hasRole('ADMIN')")
+    public ApiResult<Void> deleteAnnualLeave(
+            @Parameter(description = "연차 정책 ID") @PathVariable Long id) {
+        try {
+            log.info("연차 정책 삭제 요청: ID={}", id);
+            
+            annualLeaveService.deleteAnnualLeave(id);
+            
+            return ApiResult.success("연차 정책이 성공적으로 삭제되었습니다.", null);
+        } catch (Exception e) {
+            log.error("연차 정책 삭제 실패: {}", e.getMessage());
+            return ApiResult.failure("연차 정책 삭제에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "근무 정책별 총 연차 일수 계산", description = "특정 근무 정책의 총 연차 일수를 계산합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "총 연차 일수 계산 성공"),
+        @ApiResponse(responseCode = "404", description = "근무 정책을 찾을 수 없음")
+    })
+    @GetMapping("/work-policies/{workPolicyId}/total-leave-days")
+    public ApiResult<Integer> calculateTotalLeaveDays(
+            @Parameter(description = "근무 정책 ID") @PathVariable Long workPolicyId) {
+        try {
+            log.info("총 연차 일수 계산 요청: workPolicyId={}", workPolicyId);
+            
+            Integer totalDays = annualLeaveService.calculateTotalLeaveDays(workPolicyId);
+            
+            return ApiResult.success("총 연차 일수를 성공적으로 계산했습니다.", totalDays);
+        } catch (Exception e) {
+            log.error("총 연차 일수 계산 실패: {}", e.getMessage());
+            return ApiResult.failure("총 연차 일수 계산에 실패했습니다: " + e.getMessage());
+        }
+    }
+
+    @Operation(summary = "근무 정책별 총 휴일 일수 계산", description = "특정 근무 정책의 총 휴일 일수를 계산합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "총 휴일 일수 계산 성공"),
+        @ApiResponse(responseCode = "404", description = "근무 정책을 찾을 수 없음")
+    })
+    @GetMapping("/work-policies/{workPolicyId}/total-holiday-days")
+    public ApiResult<Integer> calculateTotalHolidayDays(
+            @Parameter(description = "근무 정책 ID") @PathVariable Long workPolicyId) {
+        try {
+            log.info("총 휴일 일수 계산 요청: workPolicyId={}", workPolicyId);
+            
+            Integer totalDays = annualLeaveService.calculateTotalHolidayDays(workPolicyId);
+            
+            return ApiResult.success("총 휴일 일수를 성공적으로 계산했습니다.", totalDays);
+        } catch (Exception e) {
+            log.error("총 휴일 일수 계산 실패: {}", e.getMessage());
+            return ApiResult.failure("총 휴일 일수 계산에 실패했습니다: " + e.getMessage());
+        }
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkMonitorController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkMonitorController.java
@@ -3,6 +3,13 @@ package com.hermes.attendanceservice.controller;
 import com.hermes.auth.principal.UserPrincipal;
 import com.hermes.attendanceservice.dto.workmonitor.WorkMonitorDto;
 import com.hermes.attendanceservice.service.workmonitor.WorkMonitorService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -17,6 +24,7 @@ import java.time.LocalDate;
 @RequestMapping("/api/work-monitor")
 @RequiredArgsConstructor
 @Slf4j
+@Tag(name = "Work Monitor", description = "근무 모니터링 API")
 public class WorkMonitorController {
     
     private final WorkMonitorService workMonitorService;
@@ -32,9 +40,12 @@ public class WorkMonitorController {
         return null;
     }
     
-    /**
-     * 오늘 날짜의 근무 모니터링 데이터 조회
-     */
+    @Operation(summary = "오늘 근무 모니터링 조회", description = "오늘 날짜의 근무 모니터링 데이터를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 모니터링 조회 성공",
+            content = @Content(schema = @Schema(implementation = WorkMonitorDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @GetMapping("/today")
     public ResponseEntity<WorkMonitorDto> getTodayWorkMonitor() {
         UserPrincipal user = getUserPrincipal();
@@ -49,12 +60,15 @@ public class WorkMonitorController {
         return ResponseEntity.ok(workMonitorDto);
     }
     
-    /**
-     * 특정 날짜의 근무 모니터링 데이터 조회
-     */
+    @Operation(summary = "특정 날짜 근무 모니터링 조회", description = "특정 날짜의 근무 모니터링 데이터를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 모니터링 조회 성공",
+            content = @Content(schema = @Schema(implementation = WorkMonitorDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @GetMapping("/{date}")
     public ResponseEntity<WorkMonitorDto> getWorkMonitorByDate(
-            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+            @Parameter(description = "날짜 (YYYY-MM-DD)") @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         UserPrincipal user = getUserPrincipal();
         if (user == null) {
             log.error("User authentication failed - UserPrincipal is null");
@@ -67,12 +81,15 @@ public class WorkMonitorController {
         return ResponseEntity.ok(workMonitorDto);
     }
     
-    /**
-     * 출석 버튼 클릭 시 근무 모니터링 데이터 갱신
-     */
+    @Operation(summary = "근무 모니터링 데이터 갱신", description = "특정 날짜의 근무 모니터링 데이터를 갱신합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 모니터링 갱신 성공",
+            content = @Content(schema = @Schema(implementation = WorkMonitorDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/update/{date}")
     public ResponseEntity<WorkMonitorDto> updateWorkMonitorData(
-            @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
+            @Parameter(description = "날짜 (YYYY-MM-DD)") @PathVariable @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
         UserPrincipal user = getUserPrincipal();
         if (user == null) {
             log.error("User authentication failed - UserPrincipal is null");
@@ -85,9 +102,12 @@ public class WorkMonitorController {
         return ResponseEntity.ok(workMonitorDto);
     }
     
-    /**
-     * 오늘 날짜의 근무 모니터링 데이터 갱신
-     */
+    @Operation(summary = "오늘 근무 모니터링 데이터 갱신", description = "오늘 날짜의 근무 모니터링 데이터를 갱신합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 모니터링 갱신 성공",
+            content = @Content(schema = @Schema(implementation = WorkMonitorDto.class))),
+        @ApiResponse(responseCode = "401", description = "인증 실패")
+    })
     @PostMapping("/update/today")
     public ResponseEntity<WorkMonitorDto> updateTodayWorkMonitorData() {
         UserPrincipal user = getUserPrincipal();

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkPolicyController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkPolicyController.java
@@ -6,6 +6,13 @@ import com.hermes.attendanceservice.dto.workpolicy.WorkPolicyResponseDto;
 import com.hermes.attendanceservice.entity.workpolicy.WorkPolicy;
 import com.hermes.attendanceservice.entity.workpolicy.WorkType;
 import com.hermes.attendanceservice.repository.workpolicy.WorkPolicyRepository;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -18,16 +25,22 @@ import java.util.List;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/workpolicy")
+@Tag(name = "Work Policy", description = "근무 정책 관리 API")
 public class WorkPolicyController {
     
     private final WorkPolicyRepository workPolicyRepository;
     
-    /**
-     * 근무 정책 생성
-     */
+    @Operation(summary = "근무 정책 생성", description = "새로운 근무 정책을 생성합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 정책 생성 성공",
+            content = @Content(schema = @Schema(implementation = WorkPolicyResponseDto.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청"),
+        @ApiResponse(responseCode = "403", description = "권한 없음")
+    })
     @PostMapping
     @PreAuthorize("hasRole('ADMIN')")
-    public ApiResult<WorkPolicyResponseDto> createWorkPolicy(@Valid @RequestBody WorkPolicyRequestDto requestDto) {
+    public ApiResult<WorkPolicyResponseDto> createWorkPolicy(
+            @Parameter(description = "근무 정책 생성 정보") @Valid @RequestBody WorkPolicyRequestDto requestDto) {
         try {
             log.info("Creating work policy: {}", requestDto.getName());
             
@@ -71,9 +84,12 @@ public class WorkPolicyController {
         }
     }
     
-    /**
-     * 전체 근무 정책 목록 조회
-     */
+    @Operation(summary = "전체 근무 정책 목록 조회", description = "모든 근무 정책 목록을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 정책 목록 조회 성공",
+            content = @Content(schema = @Schema(implementation = WorkPolicyResponseDto.class))),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
     @GetMapping
     public ApiResult<List<WorkPolicyResponseDto>> getAllWorkPolicies() {
         try {
@@ -92,11 +108,15 @@ public class WorkPolicyController {
         }
     }
     
-    /**
-     * WorkPolicy ID로 근무 정책 정보 조회
-     */
+    @Operation(summary = "근무 정책 조회", description = "ID로 특정 근무 정책을 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "근무 정책 조회 성공",
+            content = @Content(schema = @Schema(implementation = WorkPolicyResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "근무 정책을 찾을 수 없음")
+    })
     @GetMapping("/{workPolicyId}")
-    public ApiResult<WorkPolicyResponseDto> getWorkPolicyById(@PathVariable Long workPolicyId) {
+    public ApiResult<WorkPolicyResponseDto> getWorkPolicyById(
+            @Parameter(description = "근무 정책 ID") @PathVariable Long workPolicyId) {
         try {
             log.info("Get work policy by id: {}", workPolicyId);
             

--- a/attendance-service/src/main/resources/application.yml
+++ b/attendance-service/src/main/resources/application.yml
@@ -59,3 +59,13 @@ jwt:
   secret: 404E635266556A586E3272357538782F413F4428472B4B6250645367566B5970
   expiration-time: 86400000 # 24시간 (밀리초)
   refresh-expiration: 604800000 # 7일 (밀리초)
+
+# Swagger OpenAPI Configuration
+springdoc:
+  api-docs:
+    path: /api-docs
+  swagger-ui:
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+  packages-to-scan: com.hermes.attendanceservice.controller


### PR DESCRIPTION
## 이슈 번호

close #107 

## 작업 사항
- OpenAPI 3.0.1 스펙 기반 API 문서화 추가
- 근태 관리 서비스 API 엔드포인트 문서화
- 출근/퇴근, 근무 스케줄, 근무 정책, 연차 정책, 휴가 신청, 근무 모니터링 API 스펙 정의
- API 요청/응답 스키마 및 타입 정의
- 각 API별 상세 설명 및 예제 추가
- attendance-service-api-docs.json 파일 생성

## 스크린샷 (선택)


## 공유사항























