### PR TITLE
feat(be): 출근 시간 한국 표준시(KST)로 표시하도록 설정

### DIFF
--- a/attendance-service/src/main/resources/application.yml
+++ b/attendance-service/src/main/resources/application.yml
@@ -4,6 +4,9 @@ spring:
   config:
     import: optional:configserver:http://localhost:8888
 
+  jackson:
+    time-zone: Asia/Seoul
+
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -13,6 +16,7 @@ spring:
       hibernate:
         format_sql: true
         jdbc:
+          time_zone: Asia/Seoul
           lob:
             non_contextual_creation: true
 


### PR DESCRIPTION
## 이슈 번호

close #

## 작업 사항
서버 타임존을 Asia/Seoul로 고정
날짜/시간 직렬화 시 KST 기준으로 변환
API 응답의 출근 시간 필드 한국 시간으로 노출
기존 UTC 표시에 대한 혼동 방지 및 일관성 확보

## 스크린샷 (선택)


## 공유사항























