### PR TITLE
Revert "feat(be): 출근 시간 한국 표준시(KST)로 표시하도록 설정"

### DIFF
--- a/attendance-service/src/main/resources/application.yml
+++ b/attendance-service/src/main/resources/application.yml
@@ -4,9 +4,6 @@ spring:
   config:
     import: optional:configserver:http://localhost:8888
 
-  jackson:
-    time-zone: Asia/Seoul
-
   jpa:
     database-platform: org.hibernate.dialect.PostgreSQLDialect
     hibernate:
@@ -16,7 +13,6 @@ spring:
       hibernate:
         format_sql: true
         jdbc:
-          time_zone: Asia/Seoul
           lob:
             non_contextual_creation: true
 


### PR DESCRIPTION
Reverts backend20250319/BE09-Final-4team-BE#120

서버는 UTC 시간대를 사용해야 합니다.
모든 API는 UTC 시간을 반환해야 하며, 이를 로컬 시간대로 변환하여 표시하는 것은 클라이언트의 책임입니다.
또한 `LocalDateTime` 사용을 지양해야 하며, 대신 `Instant`를 사용하는 게 좋습니다.