### PR TITLE
사내 문서함 API 구현 및 attachment-service swagger 설정 추가

### DIFF
--- a/attachment-service/src/main/java/com/hermes/attachmentservice/config/OpenApiConfig.java
+++ b/attachment-service/src/main/java/com/hermes/attachmentservice/config/OpenApiConfig.java
@@ -14,7 +14,7 @@ import org.springframework.context.annotation.Configuration;
 @OpenAPIDefinition(
     info = @Info(
         title = "Hermes Attachment Service API",
-        description = "파일 업로드를 위한 REST API",
+        description = "파일 업로드 및 다운로드 관리를 위한 REST API",
         version = "1.0.0"
     ),
     security = @SecurityRequirement(name = "Bearer Authentication")

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/controller/AnnouncementController.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/controller/AnnouncementController.java
@@ -123,4 +123,18 @@ public class AnnouncementController {
     return ResponseEntity.ok(ApiResult.success("공지사항 삭제 완료", null));
   }
 
+  @Operation(summary = "공지사항 검색", description = "공지사항 제목으로 검색합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "공지사항 검색 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "403", description = "권한 부족"),
+      @ApiResponse(responseCode = "404", description = "공지사항을 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @GetMapping("/search")
+  public ResponseEntity<ApiResult<List<AnnouncementSummaryDto>>> searchAnnouncements(@RequestParam("keyword") String keyword) {
+    List<AnnouncementSummaryDto> responses = announcementService.searchAnnouncement(keyword);
+    return ResponseEntity.ok(ApiResult.success(responses));
+  }
+
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementCreateRequestDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementCreateRequestDto.java
@@ -1,6 +1,6 @@
 package com.hermes.communicationservice.announcement.dto;
 
-
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -20,7 +20,8 @@ public class AnnouncementCreateRequestDto {
   private String title;
   @Size(max = 100)
   private String displayAuthor;
-  private String content;
+  @NotNull(message = "내용은 필수입니다.")
+  private JsonNode content;
   @Builder.Default
   private List<String> fileIds = new ArrayList<>();
 

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementResponseDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementResponseDto.java
@@ -20,6 +20,7 @@ public class AnnouncementResponseDto {
     private String displayAuthor;
     private JsonNode content;
     private LocalDateTime createdAt;
+    private int views;
     private List<String> fileIds;
 
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementResponseDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementResponseDto.java
@@ -1,5 +1,6 @@
 package com.hermes.communicationservice.announcement.dto;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,7 +18,7 @@ public class AnnouncementResponseDto {
     private Long id;
     private String title;
     private String displayAuthor;
-    private String content;
+    private JsonNode content;
     private LocalDateTime createdAt;
     private List<String> fileIds;
 

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementUpdateRequestDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/dto/AnnouncementUpdateRequestDto.java
@@ -1,6 +1,6 @@
 package com.hermes.communicationservice.announcement.dto;
 
-import java.util.ArrayList;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.util.List;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,7 +18,7 @@ public class AnnouncementUpdateRequestDto {
   private String title;
   @Size(max = 100)
   private String displayAuthor;
-  private String content;
+  private JsonNode content;
   private List<String> fileIds;
 
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/entity/Announcement.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/entity/Announcement.java
@@ -1,7 +1,9 @@
 package com.hermes.communicationservice.announcement.entity;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.hermes.communicationservice.comment.entity.Comment;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
 import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityListeners;
@@ -17,6 +19,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -39,7 +43,9 @@ public class Announcement {
 
   private String displayAuthor; // 화면에 공지 작성자로 표시될 이름
 
-  private String content;
+  @JdbcTypeCode(SqlTypes.JSON)
+  @Column(name = "content", columnDefinition = "jsonb")
+  private JsonNode content;
 
   @CreatedDate
   private LocalDateTime createdAt; // 공지사항 발행 시간

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
@@ -21,8 +21,8 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
   @Query("update Announcement a set a.views = a.views + 1 where a.id = :id")
   int increaseViews(@Param("id") Long id);
 
-  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.comments LEFT JOIN FETCH a.fileIds WHERE a.id = :id")
-  Optional<Announcement> findByIdWithComments(@Param("id") Long id);
+  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.fileIds WHERE a.id = :id")
+  Optional<Announcement> findByIdWithFileIds(@Param("id") Long id);
 
   List<AnnouncementSummaryDto> findByTitleContaining(String keyword);
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
@@ -13,7 +13,7 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
 
   @Query("select new com.hermes.communicationservice.announcement.dto.AnnouncementSummaryDto(" +
       "a.id, a.title, a.displayAuthor, a.views, size(a.comments), a.createdAt) " +
-      "from Announcement a" + " order by a.id asc")
+      "from Announcement a" + " order by a.id desc")
   List<AnnouncementSummaryDto> findAllAnnouncementSummary();
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
@@ -22,4 +22,6 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
 
   @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.fileIds WHERE a.id = :id")
   Optional<Announcement> findByIdWithFileIds(@Param("id") Long id);
+
+  List<AnnouncementSummaryDto> findByTitleContaining(String keyword);
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
@@ -21,7 +21,7 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
   @Query("update Announcement a set a.views = a.views + 1 where a.id = :id")
   int increaseViews(@Param("id") Long id);
 
-  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.comments WHERE a.id = :id")
+  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.comments LEFT JOIN FETCH a.fileIds WHERE a.id = :id")
   Optional<Announcement> findByIdWithComments(@Param("id") Long id);
 
   List<AnnouncementSummaryDto> findByTitleContaining(String keyword);

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
@@ -13,7 +13,7 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
 
   @Query("SELECT new com.hermes.communicationservice.announcement.dto.AnnouncementSummaryDto(" +
       "a.id, a.title, a.displayAuthor, a.views, " +
-      "(SELECT COUNT(c) FROM Comment c WHERE c.announcement.id = a.id), a.createdAt) " +
+      "CAST((SELECT COUNT(c) FROM Comment c WHERE c.announcement.id = a.id) AS int), a.createdAt) " +
       "FROM Announcement a ORDER BY a.id DESC")
   List<AnnouncementSummaryDto> findAllAnnouncementSummary();
 

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
@@ -11,17 +11,18 @@ import org.springframework.data.repository.query.Param;
 
 public interface AnnouncementRepository extends JpaRepository<Announcement, Long> {
 
-  @Query("select new com.hermes.communicationservice.announcement.dto.AnnouncementSummaryDto(" +
-      "a.id, a.title, a.displayAuthor, a.views, size(a.comments), a.createdAt) " +
-      "from Announcement a" + " order by a.id desc")
+  @Query("SELECT new com.hermes.communicationservice.announcement.dto.AnnouncementSummaryDto(" +
+      "a.id, a.title, a.displayAuthor, a.views, " +
+      "(SELECT COUNT(c) FROM Comment c WHERE c.announcement.id = a.id), a.createdAt) " +
+      "FROM Announcement a ORDER BY a.id DESC")
   List<AnnouncementSummaryDto> findAllAnnouncementSummary();
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("update Announcement a set a.views = a.views + 1 where a.id = :id")
   int increaseViews(@Param("id") Long id);
 
-  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.fileIds WHERE a.id = :id")
-  Optional<Announcement> findByIdWithFileIds(@Param("id") Long id);
+  @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.comments WHERE a.id = :id")
+  Optional<Announcement> findByIdWithComments(@Param("id") Long id);
 
   List<AnnouncementSummaryDto> findByTitleContaining(String keyword);
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/service/AnnouncementService.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/service/AnnouncementService.java
@@ -86,7 +86,7 @@ public class AnnouncementService {
   public AnnouncementResponseDto getAnnouncement(Long id) {
 
     // 1. 공지사항 엔터티 조회
-    Announcement announcement = announcementRepository.findByIdWithFileIds(id)
+    Announcement announcement = announcementRepository.findByIdWithComments(id)
         .orElseThrow(() -> new AnnouncementNotFoundException(id));
 
     // 2. 조회수 증가

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/service/AnnouncementService.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/service/AnnouncementService.java
@@ -8,6 +8,7 @@ import com.hermes.communicationservice.announcement.dto.AnnouncementUpdateReques
 import com.hermes.communicationservice.announcement.entity.Announcement;
 import com.hermes.communicationservice.announcement.repository.AnnouncementRepository;
 import com.hermes.communicationservice.client.UserServiceClient;
+import com.hermes.communicationservice.notification.service.NotificationService;
 import com.hermes.notification.dto.NotificationRequest;
 import com.hermes.notification.enums.NotificationType;
 import com.hermes.notification.publisher.NotificationPublisher;
@@ -30,6 +31,7 @@ public class AnnouncementService {
   private final AnnouncementRepository announcementRepository;
   private final NotificationPublisher notificationPublisher;
   private final UserServiceClient userServiceClient;
+  private final NotificationService notificationService;
 
 
   // 생성
@@ -74,6 +76,7 @@ public class AnnouncementService {
         .displayAuthor(saved.getDisplayAuthor())
         .content(saved.getContent())
         .createdAt(saved.getCreatedAt())
+        .views(saved.getViews())
         .fileIds(new ArrayList<>(saved.getFileIds()))
         .build();
   }
@@ -96,6 +99,7 @@ public class AnnouncementService {
         .displayAuthor(announcement.getDisplayAuthor())
         .content(announcement.getContent())
         .createdAt(announcement.getCreatedAt())
+        .views(announcement.getViews() + 1)
         .fileIds(new ArrayList<>(announcement.getFileIds()))
         .build();
 
@@ -139,6 +143,7 @@ public class AnnouncementService {
         .displayAuthor(announcement.getDisplayAuthor())
         .content(announcement.getContent())
         .createdAt(announcement.getCreatedAt())
+        .views(announcement.getViews())
         .fileIds(new ArrayList<>(announcement.getFileIds()))
         .build();
 
@@ -150,11 +155,21 @@ public class AnnouncementService {
     Announcement announcement = announcementRepository.findById(id)
         .orElseThrow(() -> new AnnouncementNotFoundException(id));
 
+    // 공지사항 관련 알림 삭제
+    notificationService.deleteNotificationsByReferenceId(id, NotificationType.ANNOUNCEMENT);
+
+    // 공지사항 삭제
     announcementRepository.delete(announcement);
 
     log.info("공지사항 삭제 완료 - id: {}", id);
-
   }
+
+  // 공지 제목으로 검색
+  @Transactional(readOnly = true)
+  public List<AnnouncementSummaryDto> searchAnnouncement(String keyword) {
+    return announcementRepository.findByTitleContaining(keyword);
+  }
+
 
 }
 

--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/service/AnnouncementService.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/service/AnnouncementService.java
@@ -85,8 +85,8 @@ public class AnnouncementService {
   @Transactional
   public AnnouncementResponseDto getAnnouncement(Long id) {
 
-    // 1. 공지사항 엔터티 조회
-    Announcement announcement = announcementRepository.findByIdWithComments(id)
+    // 1. 공지사항 엔터티 조회 (fileIds 포함)
+    Announcement announcement = announcementRepository.findByIdWithFileIds(id)
         .orElseThrow(() -> new AnnouncementNotFoundException(id));
 
     // 2. 조회수 증가

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/controller/ArchiveController.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/controller/ArchiveController.java
@@ -1,0 +1,148 @@
+package com.hermes.communicationservice.archive.controller;
+
+import com.hermes.api.common.ApiResult;
+import com.hermes.auth.principal.UserPrincipal;
+import com.hermes.communicationservice.archive.dto.ArchiveCreateRequestDto;
+import com.hermes.communicationservice.archive.dto.ArchiveResponseDto;
+import com.hermes.communicationservice.archive.dto.ArchiveSummaryDto;
+import com.hermes.communicationservice.archive.dto.ArchiveUpdateRequestDto;
+import com.hermes.communicationservice.archive.service.ArchiveService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/archives")
+@RequiredArgsConstructor
+@Slf4j
+@Tag(name = "사내 문서함 관리", description = "사내 문서 생성, 조회, 수정, 삭제 API")
+public class ArchiveController {
+
+  private final ArchiveService archiveService;
+
+  @Operation(summary = "사내 문서 생성", description = "새로운 사내 문서를 생성합니다. ADMIN 권한 필요.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "201", description = "사내 문서 생성 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "403", description = "권한 부족 (ADMIN 권한 필요)"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @PreAuthorize("hasRole('ADMIN')")
+  @PostMapping
+  public ResponseEntity<ApiResult<ArchiveResponseDto>> createArchive(
+      @Parameter(description = "사내 문서 생성 요청 정보", required = true) @Valid @RequestBody ArchiveCreateRequestDto request,
+      @AuthenticationPrincipal UserPrincipal user) {
+    log.info("POST /archives 호출 - title: {}", request.getTitle());
+
+    ArchiveResponseDto response = archiveService.createArchive(request, user.getId());
+
+    log.info("사내 문서 생성 완료 - id: {}", response.getId());
+    return ResponseEntity.status(HttpStatus.CREATED)
+        .body(ApiResult.success("사내 문서 생성 완료", response));
+  }
+
+  @Operation(summary = "사내 문서 상세 조회", description = "특정 사내 문서의 상세 정보를 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사내 문서 조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "404", description = "사내 문서를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @GetMapping("/{id}")
+  public ResponseEntity<ApiResult<ArchiveResponseDto>> getArchive(
+      @Parameter(description = "사내 문서 ID", required = true, example = "1") @PathVariable Long id,
+      @AuthenticationPrincipal UserPrincipal user) {
+    log.info("GET /archives/{} 호출", id);
+    ArchiveResponseDto response = archiveService.getArchive(id);
+    return ResponseEntity.ok(ApiResult.success("사내 문서 조회 완료", response));
+  }
+
+  @Operation(summary = "사내 문서 목록 조회", description = "모든 사내 문서의 요약 목록을 조회합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사내 문서 목록 조회 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @GetMapping
+  public ResponseEntity<List<ArchiveSummaryDto>> getAllArchivesSummary(
+      @AuthenticationPrincipal UserPrincipal user) {
+    log.info("GET /archives 호출 - 요약 목록 조회");
+    List<ArchiveSummaryDto> summary = archiveService.getAllArchivesSummary();
+    return ResponseEntity.ok(summary);
+  }
+
+  @Operation(summary = "사내 문서 수정", description = "기존 사내 문서의 정보를 수정합니다. ADMIN 권한 필요.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사내 문서 수정 성공"),
+      @ApiResponse(responseCode = "400", description = "잘못된 요청 데이터"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "403", description = "권한 부족 (ADMIN 권한 필요)"),
+      @ApiResponse(responseCode = "404", description = "사내 문서를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @PreAuthorize("hasRole('ADMIN')")
+  @PatchMapping("/{id}")
+  public ResponseEntity<ApiResult<ArchiveResponseDto>> updateArchive(
+      @Parameter(description = "사내 문서 ID", required = true, example = "1") @PathVariable Long id,
+      @Parameter(description = "사내 문서 수정 요청 정보", required = true) @Valid @RequestBody ArchiveUpdateRequestDto request,
+      @AuthenticationPrincipal UserPrincipal user) {
+
+    log.info("PATCH /archives/{} 호출", id);
+    ArchiveResponseDto updated = archiveService.updateArchive(request, id, user.getId());
+    return ResponseEntity.ok(ApiResult.success("사내 문서 수정 완료", updated));
+  }
+
+  @Operation(summary = "사내 문서 삭제", description = "기존 사내 문서를 삭제합니다. ADMIN 권한 필요.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사내 문서 삭제 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "403", description = "권한 부족 (ADMIN 권한 필요)"),
+      @ApiResponse(responseCode = "404", description = "사내 문서를 찾을 수 없음"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @DeleteMapping("/{id}")
+  @PreAuthorize("hasRole('ADMIN')")
+  public ResponseEntity<ApiResult<Void>> deleteArchive(
+      @Parameter(description = "사내 문서 ID", required = true, example = "1") @PathVariable Long id,
+      @AuthenticationPrincipal UserPrincipal user) {
+    log.info("DELETE /archives/{} 호출", id);
+    archiveService.deleteArchive(id);
+    return ResponseEntity.ok(ApiResult.success("사내 문서 삭제 완료", null));
+  }
+
+  @Operation(summary = "사내 문서 검색", description = "사내 문서 제목으로 검색합니다.")
+  @ApiResponses(value = {
+      @ApiResponse(responseCode = "200", description = "사내 문서 검색 성공"),
+      @ApiResponse(responseCode = "401", description = "인증 실패"),
+      @ApiResponse(responseCode = "500", description = "서버 내부 오류")
+  })
+  @GetMapping("/search")
+  public ResponseEntity<ApiResult<List<ArchiveSummaryDto>>> searchArchives(
+      @Parameter(description = "검색 키워드", required = true, example = "규정") @RequestParam("keyword") String keyword,
+      @AuthenticationPrincipal UserPrincipal user) {
+    log.info("GET /archives/search 호출 - keyword: {}", keyword);
+    List<ArchiveSummaryDto> responses = archiveService.searchArchives(keyword);
+    return ResponseEntity.ok(ApiResult.success(responses));
+  }
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveCreateRequestDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveCreateRequestDto.java
@@ -1,0 +1,32 @@
+package com.hermes.communicationservice.archive.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사내 문서 생성 요청")
+public class ArchiveCreateRequestDto {
+
+  @NotBlank(message = "제목은 필수입니다")
+  @Schema(description = "문서 제목", example = "2024년 사내 규정 업데이트")
+  private String title;
+
+  @Schema(description = "문서 설명", example = "2024년 개정된 사내 규정에 대한 안내 문서입니다")
+  private String description;
+
+  @NotNull(message = "첨부파일 목록은 필수입니다")
+  @Schema(description = "첨부파일 ID 목록", example = "[\"file1\", \"file2\"]")
+  private List<String> fileIds;
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveResponseDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveResponseDto.java
@@ -1,0 +1,38 @@
+package com.hermes.communicationservice.archive.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사내 문서 상세 응답")
+public class ArchiveResponseDto {
+
+  @Schema(description = "문서 ID", example = "1")
+  private Long id;
+
+  @Schema(description = "문서 제목", example = "2024년 사내 규정 업데이트")
+  private String title;
+
+  @Schema(description = "문서 작성자 ID", example = "123")
+  private Long authorId;
+
+  @Schema(description = "문서 설명", example = "2024년 개정된 사내 규정에 대한 안내 문서입니다")
+  private String description;
+
+  @Schema(description = "첨부파일 ID 목록", example = "[\"file1\", \"file2\"]")
+  private List<String> fileIds;
+
+  @Schema(description = "생성일시", example = "2024-01-15T09:00:00")
+  private LocalDateTime createdAt;
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveSummaryDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveSummaryDto.java
@@ -1,0 +1,25 @@
+package com.hermes.communicationservice.archive.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사내 문서 목록 응답")
+public class ArchiveSummaryDto {
+
+  @Schema(description = "문서 ID", example = "1")
+  private Long id;
+
+  @Schema(description = "문서 제목", example = "2024년 사내 규정 업데이트")
+  private String title;
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveUpdateRequestDto.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/dto/ArchiveUpdateRequestDto.java
@@ -1,0 +1,28 @@
+package com.hermes.communicationservice.archive.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "사내 문서 수정 요청")
+public class ArchiveUpdateRequestDto {
+
+  @Schema(description = "문서 제목", example = "2024년 사내 규정 업데이트 (수정)")
+  private String title;
+
+  @Schema(description = "문서 설명", example = "2024년 개정된 사내 규정에 대한 수정된 안내 문서입니다")
+  private String description;
+
+  @Schema(description = "첨부파일 ID 목록", example = "[\"file1\", \"file2\", \"file3\"]")
+  private List<String> fileIds;
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/entity/Archive.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/entity/Archive.java
@@ -1,0 +1,49 @@
+package com.hermes.communicationservice.archive.entity;
+
+import jakarta.persistence.ElementCollection;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Table(name = "archives")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class Archive {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  private String title;
+
+  private Long authorId; // 사내 문서 발행자
+
+  private String description; // 사내 문서 설명
+
+  // 첨부파일 fileId 리스트
+  @ElementCollection
+  @Builder.Default
+  private List<String> fileIds = new ArrayList<>();
+
+  @CreatedDate
+  private LocalDateTime createdAt;
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/repository/ArchiveRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/repository/ArchiveRepository.java
@@ -1,0 +1,14 @@
+package com.hermes.communicationservice.archive.repository;
+
+import com.hermes.communicationservice.archive.entity.Archive;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface ArchiveRepository extends JpaRepository<Archive, Long> {
+
+  @Query("SELECT a FROM Archive a WHERE a.title LIKE %:keyword%")
+  List<Archive> findByTitleContaining(@Param("keyword") String keyword);
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/archive/service/ArchiveService.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/archive/service/ArchiveService.java
@@ -1,0 +1,117 @@
+package com.hermes.communicationservice.archive.service;
+
+import com.hermes.communicationservice.archive.dto.ArchiveCreateRequestDto;
+import com.hermes.communicationservice.archive.dto.ArchiveResponseDto;
+import com.hermes.communicationservice.archive.dto.ArchiveSummaryDto;
+import com.hermes.communicationservice.archive.dto.ArchiveUpdateRequestDto;
+import com.hermes.communicationservice.archive.entity.Archive;
+import com.hermes.communicationservice.archive.repository.ArchiveRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional(readOnly = true)
+public class ArchiveService {
+
+  private final ArchiveRepository archiveRepository;
+
+  @Transactional
+  public ArchiveResponseDto createArchive(ArchiveCreateRequestDto request, Long authorId) {
+    log.info("사내 문서 생성 - title: {}, authorId: {}", request.getTitle(), authorId);
+    
+    Archive archive = Archive.builder()
+        .title(request.getTitle())
+        .description(request.getDescription())
+        .authorId(authorId)
+        .fileIds(request.getFileIds())
+        .build();
+
+    Archive savedArchive = archiveRepository.save(archive);
+    log.info("사내 문서 생성 완료 - id: {}", savedArchive.getId());
+
+    return convertToResponseDto(savedArchive);
+  }
+
+  public List<ArchiveSummaryDto> getAllArchivesSummary() {
+    log.info("사내 문서 목록 조회");
+    
+    return archiveRepository.findAll().stream()
+        .map(this::convertToSummaryDto)
+        .toList();
+  }
+
+  public ArchiveResponseDto getArchive(Long id) {
+    log.info("사내 문서 상세 조회 - id: {}", id);
+    
+    Archive archive = archiveRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문서입니다: " + id));
+
+    return convertToResponseDto(archive);
+  }
+
+  @Transactional
+  public ArchiveResponseDto updateArchive(ArchiveUpdateRequestDto request, Long id, Long authorId) {
+    log.info("사내 문서 수정 - id: {}, authorId: {}", id, authorId);
+    
+    Archive archive = archiveRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문서입니다: " + id));
+
+    if (request.getTitle() != null) {
+      archive.setTitle(request.getTitle());
+    }
+    if (request.getDescription() != null) {
+      archive.setDescription(request.getDescription());
+    }
+    if (request.getFileIds() != null) {
+      archive.setFileIds(request.getFileIds());
+    }
+
+    Archive updatedArchive = archiveRepository.save(archive);
+    log.info("사내 문서 수정 완료 - id: {}", updatedArchive.getId());
+
+    return convertToResponseDto(updatedArchive);
+  }
+
+  @Transactional
+  public void deleteArchive(Long id) {
+    log.info("사내 문서 삭제 - id: {}", id);
+    
+    Archive archive = archiveRepository.findById(id)
+        .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 문서입니다: " + id));
+
+    archiveRepository.delete(archive);
+    log.info("사내 문서 삭제 완료 - id: {}", id);
+  }
+
+  public List<ArchiveSummaryDto> searchArchives(String keyword) {
+    log.info("사내 문서 검색 - keyword: {}", keyword);
+    
+    return archiveRepository.findByTitleContaining(keyword).stream()
+        .map(this::convertToSummaryDto)
+        .toList();
+  }
+
+  private ArchiveResponseDto convertToResponseDto(Archive archive) {
+    return ArchiveResponseDto.builder()
+        .id(archive.getId())
+        .title(archive.getTitle())
+        .authorId(archive.getAuthorId())
+        .description(archive.getDescription())
+        .fileIds(archive.getFileIds())
+        .createdAt(archive.getCreatedAt())
+        .build();
+  }
+
+  private ArchiveSummaryDto convertToSummaryDto(Archive archive) {
+    return ArchiveSummaryDto.builder()
+        .id(archive.getId())
+        .title(archive.getTitle())
+        .build();
+  }
+
+}

--- a/communication-service/src/main/java/com/hermes/communicationservice/notification/repository/NotificationRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/notification/repository/NotificationRepository.java
@@ -24,4 +24,8 @@ public interface NotificationRepository extends JpaRepository<Notification, Long
   @Query("UPDATE Notification n SET n.isRead = true WHERE n.id = :id")
   int markAsRead(@Param("id") Long id);
 
+  @Modifying
+  @Query("DELETE FROM Notification n WHERE n.referenceId = :referenceId AND n.type = :type")
+  int deleteByReferenceIdAndType(@Param("referenceId") Long referenceId, @Param("type") com.hermes.notification.enums.NotificationType type);
+
 }

--- a/communication-service/src/main/java/com/hermes/communicationservice/notification/service/NotificationService.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/notification/service/NotificationService.java
@@ -6,9 +6,11 @@ import com.hermes.communicationservice.notification.entity.Notification;
 import com.hermes.communicationservice.notification.exception.NotificationAccessDeniedException;
 import com.hermes.communicationservice.notification.exception.NotificationNotFoundException;
 import com.hermes.communicationservice.notification.repository.NotificationRepository;
+import com.hermes.notification.enums.NotificationType;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -16,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 @Transactional(readOnly = true)
 public class NotificationService {
 
@@ -60,6 +63,15 @@ public class NotificationService {
     
     int updated = notificationRepository.markAsRead(notificationId);
     return updated > 0;
+  }
+
+  @Transactional
+  public void deleteNotificationsByReferenceId(Long referenceId, NotificationType type) {
+    log.info("알림 삭제 - referenceId: {}, type: {}", referenceId, type);
+    
+    int deletedCount = notificationRepository.deleteByReferenceIdAndType(referenceId, type);
+    
+    log.info("알림 삭제 완료 - referenceId: {}, type: {}, deletedCount: {}", referenceId, type, deletedCount);
   }
 
 }

--- a/gateway-server/src/main/java/com/hermes/gatewayserver/config/GatewayOpenApiConfig.java
+++ b/gateway-server/src/main/java/com/hermes/gatewayserver/config/GatewayOpenApiConfig.java
@@ -33,6 +33,7 @@ public class GatewayOpenApiConfig {
             urls.add(new AbstractSwaggerUiConfigProperties.SwaggerUrl("leave-service", "/v3/api-docs/leave-service", "leave-service"));
             urls.add(new AbstractSwaggerUiConfigProperties.SwaggerUrl("companyinfo-service", "/v3/api-docs/companyinfo-service", "companyinfo-service"));
             urls.add(new AbstractSwaggerUiConfigProperties.SwaggerUrl("communication-service", "/v3/api-docs/communication-service", "communication-service"));
+            urls.add(new AbstractSwaggerUiConfigProperties.SwaggerUrl("attachment-service", "/v3/api-docs/attachment-service", "attachment-service"));
             
             swaggerUiConfigProperties.setUrls(urls);
         };

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -23,7 +23,7 @@ spring:
             - id: communication-service
               uri: lb://communication-service
               predicates:
-                - Path=/api/announcements/**,/api/comments/**,/api/notifications/**
+                - Path=/api/announcements/**,/api/comments/**,/api/notifications/**,/api/archives/**
             - id: attendance-service
               uri: lb://attendance-service
               predicates:

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -108,6 +108,7 @@ spring:
                   - GET
                   - POST
                   - PUT
+                  - PATCH
                   - DELETE
                   - OPTIONS
                 allowedHeaders:

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -92,6 +92,12 @@ spring:
                 - Path=/v3/api-docs/communication-service
               filters:
                 - RewritePath=/v3/api-docs/communication-service, /v3/api-docs
+            - id: attachment-service-docs
+              uri: lb://attachment-service
+              predicates:
+                - Path=/v3/api-docs/attachment-service
+              filters:
+                - RewritePath=/v3/api-docs/attachment-service, /v3/api-docs
 
           globalcors:
             cors-configurations:

--- a/gateway-server/src/main/resources/application.yml
+++ b/gateway-server/src/main/resources/application.yml
@@ -31,7 +31,7 @@ spring:
             - id: attachment-service
               uri: lb://attachment-service
               predicates:
-                - Path=/api/attachment/**
+                - Path=/api/attachments/**
             - id: org-service
               uri: lb://org-service
               predicates:


### PR DESCRIPTION
## 이슈 번호

close #118 

## 작업 사항
- gateway에 attachment-service 라우팅을 수정 (/api/attachment -> /api/attachments)
- gateway에 attachment-service의 문서 라우팅을 추가
- gateway의 CORS 설정에 patch 메서드 허용
- announcement의 content를 string -> jsonb로 변경 (lexical editor 데이터 그대로 저장 위해)
- 공지사항 ID로 알림을 삭제하는 로직을 추가 (공지사항 삭제 시 자동 처리 위함)
- 공지사항 응답값에 view를 추가 (프론트 연동 위함)
- 사내 문서함(archive) 관련 API를 구현하고 gateway에 라우팅을 추가


## 스크린샷 (선택)


## 공유사항
gateway의 application.yml에 변동이 있습니다. 
다들 최신화해주시면 좋을 것 같습니다.






















