### PR TITLE
공지사항 제목 검색에서 다른 반환값을 반환하는 쿼리 수정

### DIFF
--- a/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
+++ b/communication-service/src/main/java/com/hermes/communicationservice/announcement/repository/AnnouncementRepository.java
@@ -24,5 +24,9 @@ public interface AnnouncementRepository extends JpaRepository<Announcement, Long
   @Query("SELECT a FROM Announcement a LEFT JOIN FETCH a.fileIds WHERE a.id = :id")
   Optional<Announcement> findByIdWithFileIds(@Param("id") Long id);
 
-  List<AnnouncementSummaryDto> findByTitleContaining(String keyword);
+  @Query("SELECT new com.hermes.communicationservice.announcement.dto.AnnouncementSummaryDto(" +
+      "a.id, a.title, a.displayAuthor, a.views, " +
+      "CAST((SELECT COUNT(c) FROM Comment c WHERE c.announcement.id = a.id) AS int), a.createdAt) " +
+      "FROM Announcement a WHERE a.title LIKE %:keyword% ORDER BY a.id DESC")
+  List<AnnouncementSummaryDto> findByTitleContaining(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
## 작업 사항
- 쿼리메소드를 사용하여 findByTitleContaining이 announcementSummaryDto를 잘 반환하도록 수정






















