### PR TITLE
Feature/workpolicy api integration

### DIFF
--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/AttendanceController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/AttendanceController.java
@@ -25,7 +25,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 
 @Slf4j
@@ -53,7 +53,6 @@ public class AttendanceController {
             if (!user.getId().equals(request.getUserId())) {
                 return ApiResult.failure("권한이 없습니다.");
             }
-            
             AttendanceResponse response = attendanceService.checkIn(request.getUserId(), request.getCheckIn());
             return ApiResult.success("출근 기록이 성공적으로 등록되었습니다.", response);
         } catch (Exception e) {
@@ -77,7 +76,6 @@ public class AttendanceController {
             if (!user.getId().equals(request.getUserId())) {
                 return ApiResult.failure("권한이 없습니다.");
             }
-            
             AttendanceResponse response = attendanceService.checkOut(request.getUserId(), request.getCheckOut());
             return ApiResult.success("퇴근 기록이 성공적으로 등록되었습니다.", response);
         } catch (Exception e) {
@@ -93,14 +91,14 @@ public class AttendanceController {
         @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @PostMapping("/attendance-status")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ApiResult<AttendanceResponse> markAttendanceStatus(
             @Parameter(description = "직원 ID") @RequestParam Long userId,
             @Parameter(description = "날짜 (YYYY-MM-DD)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(description = "출근 상태") @RequestParam AttendanceStatus attendanceStatus,
             @Parameter(description = "자동 기록 여부") @RequestParam(defaultValue = "true") boolean autoRecorded,
-            @Parameter(description = "출근 시간 (선택사항)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime checkInTime,
-            @Parameter(description = "퇴근 시간 (선택사항)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime checkOutTime) {
+            @Parameter(description = "출근 시간 (선택사항, ISO-8601 Instant)") @RequestParam(required = false) Instant checkInTime,
+            @Parameter(description = "퇴근 시간 (선택사항, ISO-8601 Instant)") @RequestParam(required = false) Instant checkOutTime) {
         try {
             AttendanceResponse response = attendanceService.markAttendanceStatus(userId, date, attendanceStatus, autoRecorded, checkInTime, checkOutTime);
             return ApiResult.success("출근 상태가 성공적으로 기록되었습니다.", response);
@@ -117,14 +115,14 @@ public class AttendanceController {
         @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @PostMapping("/work-status")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ApiResult<AttendanceResponse> markWorkStatus(
             @Parameter(description = "직원 ID") @RequestParam Long userId,
             @Parameter(description = "날짜 (YYYY-MM-DD)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate date,
             @Parameter(description = "근무 상태") @RequestParam WorkStatus workStatus,
             @Parameter(description = "자동 기록 여부") @RequestParam(defaultValue = "true") boolean autoRecorded,
-            @Parameter(description = "출근 시간 (선택사항)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime checkInTime,
-            @Parameter(description = "퇴근 시간 (선택사항)") @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime checkOutTime) {
+            @Parameter(description = "출근 시간 (선택사항, ISO-8601 Instant)") @RequestParam(required = false) Instant checkInTime,
+            @Parameter(description = "퇴근 시간 (선택사항, ISO-8601 Instant)") @RequestParam(required = false) Instant checkOutTime) {
         try {
             AttendanceResponse response = attendanceService.markWorkStatus(userId, date, workStatus, autoRecorded, checkInTime, checkOutTime);
             return ApiResult.success("근무 상태가 성공적으로 기록되었습니다.", response);
@@ -135,7 +133,7 @@ public class AttendanceController {
 
     /** 이번 주 근무 상세 */
     @GetMapping("/weekly/this")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ApiResult<WeeklyWorkDetail> getThisWeek(@RequestParam Long userId) {
         try {
             WeeklyWorkSummary summary = attendanceService.getThisWeekSummary(userId);
@@ -155,7 +153,7 @@ public class AttendanceController {
 
     /** 특정 주 (weekStart가 요일이 아니어도 자동 보정) */
     @GetMapping("/weekly")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ApiResult<WeeklyWorkDetail> getWeek(
             @RequestParam Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate weekStart) {
@@ -177,7 +175,7 @@ public class AttendanceController {
 
     /** 출근 가능 시간 조회 */
     @GetMapping("/check-in-available-time")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ApiResult<Map<String, Object>> getCheckInAvailableTime(@RequestParam Long userId) {
         try {
             Map<String, Object> response = attendanceService.getCheckInAvailableTime(userId);

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkScheduleController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkScheduleController.java
@@ -91,7 +91,7 @@ public class WorkScheduleController {
             return ResponseEntity.ok(ApiResult.success("스케줄 생성 성공", result));
         } catch (Exception e) {
             log.error("Error creating schedule for userId: {}", requestDto.getUserId(), e);
-            return ResponseEntity.ok(ApiResult.failure("스케줄 생성 중 오류가 발생했습니다."));
+            return ResponseEntity.ok(ApiResult.failure("스케줄 생성 실패: " + e.getMessage()));
         }
     }
     
@@ -103,7 +103,7 @@ public class WorkScheduleController {
         @ApiResponse(responseCode = "403", description = "권한 없음")
     })
     @PostMapping("/users/{userId}/fixed-schedules")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<List<ScheduleResponseDto>>> createFixedSchedules(
             @Parameter(description = "사용자 ID") @PathVariable Long userId,
             @Parameter(description = "시작 날짜 (YYYY-MM-DD)") @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -123,7 +123,7 @@ public class WorkScheduleController {
      * 근무시간, 휴게시간, 출근시간, 퇴근시간, 코어시간, 시차 근무 출근 가능 시간 등을 스케줄로 생성
      */
     @PostMapping("/users/{userId}/apply-work-policy")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<List<ScheduleResponseDto>>> applyWorkPolicyToSchedule(
             @PathVariable Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -142,7 +142,7 @@ public class WorkScheduleController {
      * 스케줄 수정
      */
     @PutMapping("/users/{userId}/schedules/{scheduleId}")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<ScheduleResponseDto>> updateSchedule(
             @PathVariable Long userId,
             @PathVariable Long scheduleId,
@@ -161,7 +161,7 @@ public class WorkScheduleController {
      * 스케줄 삭제
      */
     @DeleteMapping("/users/{userId}/schedules/{scheduleId}")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<Void>> deleteSchedule(
             @PathVariable Long userId,
             @PathVariable Long scheduleId) {
@@ -179,7 +179,7 @@ public class WorkScheduleController {
      * 사용자별 스케줄 조회 (WorkPolicy 정보 포함)
      */
     @GetMapping("/users/{userId}/schedules")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<List<ScheduleResponseDto>>> getUserSchedules(
             @PathVariable Long userId) {
         try {
@@ -195,7 +195,7 @@ public class WorkScheduleController {
      * 사용자별 특정 기간 스케줄 조회
      */
     @GetMapping("/users/{userId}/schedules/range")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<List<ScheduleResponseDto>>> getUserSchedulesByDateRange(
             @PathVariable Long userId,
             @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate startDate,
@@ -213,7 +213,7 @@ public class WorkScheduleController {
      * 스케줄 상세 조회
      */
     @GetMapping("/users/{userId}/schedules/{scheduleId}")
-    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.userId")
+    @PreAuthorize("hasRole('ADMIN') or #userId == authentication.principal.id")
     public ResponseEntity<ApiResult<ScheduleResponseDto>> getScheduleById(
             @PathVariable Long userId,
             @PathVariable Long scheduleId) {

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/attendance/AttendanceResponse.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/attendance/AttendanceResponse.java
@@ -7,7 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Builder
@@ -19,11 +19,9 @@ public class AttendanceResponse {
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate date; // 근무 날짜
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime checkIn; // 출근 시간
+    private Instant checkIn; // 출근 시간 (UTC Instant)
 
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime checkOut; // 퇴근 시간
+    private Instant checkOut; // 퇴근 시간 (UTC Instant)
 
     private AttendanceStatus attendanceStatus; // 출근 상태 (REGULAR, LATE, NOT_CLOCKIN, ABSENT)
     private WorkStatus workStatus; // 근무 상태 (OFFICE, REMOTE, VACATION, BUSINESS_TRIP 등)

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/attendance/CheckInRequest.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/attendance/CheckInRequest.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Builder
@@ -12,5 +12,5 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class CheckInRequest {
     private Long userId;              // 출근하는 사용자의 ID
-    private LocalDateTime checkIn;    // 출근 시간 (보통 서버에서 now()로 처리 가능)
+    private Instant checkIn;          // 출근 시간 (보통 서버에서 now()로 처리 가능)
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/attendance/CheckOutRequest.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/attendance/CheckOutRequest.java
@@ -4,7 +4,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Data
 @Builder
@@ -12,5 +12,5 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 public class CheckOutRequest {
     private Long userId;              // 퇴근하는 사용자의 ID
-    private LocalDateTime checkOut;    // 퇴근 시간 (보통 서버에서 now()로 처리 가능)
+    private Instant checkOut;         // 퇴근 시간 (보통 서버에서 now()로 처리 가능)
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/leave/LeaveRequestResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/leave/LeaveRequestResponseDto.java
@@ -7,7 +7,7 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.LocalTime;
 
 @Data
@@ -32,6 +32,6 @@ public class LeaveRequestResponseDto {
     private String statusName;
     private Long approverId;
     private String approverName;
-    private LocalDateTime requestedAt;
-    private LocalDateTime approvedAt;
+    private Instant requestedAt;
+    private Instant approvedAt;
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workpolicy/AnnualLeaveResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workpolicy/AnnualLeaveResponseDto.java
@@ -2,7 +2,7 @@ package com.hermes.attendanceservice.dto.workpolicy;
 
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -19,6 +19,6 @@ public class AnnualLeaveResponseDto {
     private Integer leaveDays;
     private Integer holidayDays;
     private String rangeDescription; // 범위 설명 (예: "0~1년차", "2~3년차")
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workpolicy/WorkPolicyListResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workpolicy/WorkPolicyListResponseDto.java
@@ -3,7 +3,7 @@ package com.hermes.attendanceservice.dto.workpolicy;
 import com.hermes.attendanceservice.entity.workpolicy.WorkType;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -20,8 +20,8 @@ public class WorkPolicyListResponseDto {
     private Integer totalRequiredMinutes;
     private Integer totalAnnualLeaveDays; // 총 연차 일수
     private Integer totalHolidayDays; // 총 휴일 일수
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
     
     // 계산된 필드들
     private Integer totalWorkMinutes;

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workpolicy/WorkPolicyResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workpolicy/WorkPolicyResponseDto.java
@@ -5,7 +5,7 @@ import com.hermes.attendanceservice.entity.workpolicy.WorkCycle;
 import com.hermes.attendanceservice.entity.workpolicy.WorkType;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.LocalTime;
 import java.util.List;
 
@@ -40,8 +40,8 @@ public class WorkPolicyResponseDto {
     private Boolean isHolidayFixed;
     private Boolean isBreakFixed;
     private List<AnnualLeaveResponseDto> annualLeaves;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
     
     // 계산된 필드들
     private Integer totalWorkMinutes;

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/AnnualLeaveResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/AnnualLeaveResponseDto.java
@@ -2,7 +2,7 @@ package com.hermes.attendanceservice.dto.workschedule;
 
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -19,6 +19,6 @@ public class AnnualLeaveResponseDto {
     private Integer leaveDays;
     private Integer holidayDays;
     private String rangeDescription; // 범위 설명 (예: "0~1년차", "2~3년차")
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/ScheduleResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/workschedule/ScheduleResponseDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import com.hermes.attendanceservice.entity.workschedule.ScheduleType;
 
@@ -38,8 +38,8 @@ public class ScheduleResponseDto {
     private String location;
     private List<String> attendees;
     private String notes;
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private Instant createdAt;
+    private Instant updatedAt;
     private String status; // ACTIVE, CANCELLED, COMPLETED
     private Boolean isFixed; // 고정 스케줄 여부
     private Boolean isEditable; // 편집 가능 여부

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/attendance/Attendance.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/attendance/Attendance.java
@@ -1,14 +1,10 @@
 package com.hermes.attendanceservice.entity.attendance;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
 import java.time.LocalDate;
-import java.time.LocalDateTime;
-import com.hermes.attendanceservice.entity.attendance.AttendanceStatus;
-import com.hermes.attendanceservice.entity.attendance.WorkStatus;
+import java.time.Instant;
 
 @Entity
 @Table(name = "attendance")
@@ -17,26 +13,31 @@ import com.hermes.attendanceservice.entity.attendance.WorkStatus;
 @AllArgsConstructor
 @Builder
 public class Attendance {
-  @Id
-  @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id; // 출퇴근 기록의 고유 식별자(PK)
-  
-  @Column(name = "user_id", nullable = false)
-  private Long userId; // User 엔티티의 고유 식별자(FK)
-  
-  private LocalDate date; // 출퇴근 날짜
 
-  private LocalDateTime checkIn; // 출근 시간
-  private LocalDateTime checkOut; // 퇴근 시간
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id; // 출퇴근 기록의 고유 식별자(PK)
 
-  @Enumerated(EnumType.STRING)
-  @Builder.Default
-  private AttendanceStatus attendanceStatus = AttendanceStatus.NOT_CLOCKIN; // 출근 상태
-  
-  @Enumerated(EnumType.STRING)
-  @Builder.Default
-  private WorkStatus workStatus = WorkStatus.OFFICE; // 근무 상태
-  
-  @Builder.Default
-  private boolean isAutoRecorded = false; // 자동 기록(버튼)인지, 수동 기록인지
+    @Column(name = "user_id", nullable = false)
+    private Long userId; // User 엔티티의 고유 식별자(FK)
+
+    @Column(nullable = false)
+    private LocalDate date; // 출퇴근 날짜
+
+    @Column
+    private Instant checkIn; // 출근 시간
+
+    @Column
+    private Instant checkOut; // 퇴근 시간
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private AttendanceStatus attendanceStatus = AttendanceStatus.NOT_CLOCKIN; // 출근 상태
+
+    @Enumerated(EnumType.STRING)
+    @Builder.Default
+    private WorkStatus workStatus = WorkStatus.OFFICE; // 근무 상태
+
+    @Builder.Default
+    private boolean isAutoRecorded = false; // 자동 기록 여부
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/leave/LeaveRequest.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/leave/LeaveRequest.java
@@ -7,10 +7,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.time.LocalTime;
-import java.time.Duration;
-import java.time.temporal.ChronoUnit;
 
 @Entity
 @Table(name = "leave_requests")
@@ -58,10 +56,10 @@ public class LeaveRequest {
     private Long approverId;
     
     @Column(name = "requested_at", nullable = false)
-    private LocalDateTime requestedAt;
+    private Instant requestedAt;
     
     @Column(name = "approved_at")
-    private LocalDateTime approvedAt;
+    private Instant approvedAt;
     
     public enum RequestStatus {
         REQUESTED,   // 신청
@@ -84,7 +82,7 @@ public class LeaveRequest {
                 .totalDays(totalDays)
                 .reason(createDto.getReason())
                 .status(RequestStatus.REQUESTED)
-                .requestedAt(LocalDateTime.now())
+                .requestedAt(Instant.now())
                 .build();
     }
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workpolicy/AnnualLeave.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workpolicy/AnnualLeave.java
@@ -3,7 +3,7 @@ package com.hermes.attendanceservice.entity.workpolicy;
 import jakarta.persistence.*;
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "annual_leave")
@@ -38,20 +38,20 @@ public class AnnualLeave {
     private Integer holidayDays; // 연당 휴가와는 다른 공휴일 일수 (고정)
     
     @Column(name = "created_at")
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
     
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
     }
     
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = Instant.now();
     }
     
     /**

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workpolicy/WorkPolicy.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workpolicy/WorkPolicy.java
@@ -4,8 +4,8 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -109,20 +109,20 @@ public class WorkPolicy {
     private List<AnnualLeave> annualLeaves = new ArrayList<>();
     
     @Column(name = "created_at")
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     
     @Column(name = "updated_at")
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
     
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
     }
     
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = Instant.now();
     }
     
     /**

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workschedule/Schedule.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workschedule/Schedule.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.List;
 import com.hermes.attendanceservice.entity.workschedule.ScheduleType;
 
@@ -99,10 +99,10 @@ public class Schedule {
     private String fixedReason; // 고정 사유 (WORK_POLICY, HOLIDAY, BREAK_TIME)
     
     @Column(nullable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
     
     @Column(nullable = false, length = 20)
     @Builder.Default
@@ -110,28 +110,28 @@ public class Schedule {
     
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
     }
     
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = Instant.now();
     }
     
     // 스케줄 상태 변경 메서드
     public void cancel() {
         this.status = "CANCELLED";
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = Instant.now();
     }
     
     public void complete() {
         this.status = "COMPLETED";
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = Instant.now();
     }
     
     public void activate() {
         this.status = "ACTIVE";
-        this.updatedAt = LocalDateTime.now();
+        this.updatedAt = Instant.now();
     }
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workschedule/ScheduleType.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workschedule/ScheduleType.java
@@ -9,7 +9,8 @@ public enum ScheduleType {
     VACATION("휴가"),
     BUSINESS_TRIP("출장"),
     OUT_OF_OFFICE("외근"),
-    OVERTIME("초과근무");
+    OVERTIME("초과근무"),
+    RESTTIME("휴게시간");
     
     private final String description;
     

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workschedule/WorkTimeAdjustment.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/workschedule/WorkTimeAdjustment.java
@@ -5,7 +5,7 @@ import lombok.*;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Entity
 @Table(name = "work_time_adjustments")
@@ -41,20 +41,20 @@ public class WorkTimeAdjustment {
     private String description;
     
     @Column(nullable = false)
-    private LocalDateTime createdAt;
+    private Instant createdAt;
     
     @Column(nullable = false)
-    private LocalDateTime updatedAt;
+    private Instant updatedAt;
     
     @PrePersist
     protected void onCreate() {
-        createdAt = LocalDateTime.now();
-        updatedAt = LocalDateTime.now();
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
     }
     
     @PreUpdate
     protected void onUpdate() {
-        updatedAt = LocalDateTime.now();
+        updatedAt = Instant.now();
     }
     
     // 근무 시간 계산 (분 단위)

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/attendance/AttendanceService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/attendance/AttendanceService.java
@@ -6,30 +6,30 @@ import com.hermes.attendanceservice.entity.attendance.AttendanceStatus;
 import com.hermes.attendanceservice.entity.attendance.WorkStatus;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.Map;
 
 public interface AttendanceService {
     // 출근
-    AttendanceResponse checkIn(Long userId, LocalDateTime checkInTime);
+    AttendanceResponse checkIn(Long userId, Instant checkInTime);
     // 퇴근
-    AttendanceResponse checkOut(Long userId, LocalDateTime checkOutTime);
+    AttendanceResponse checkOut(Long userId, Instant checkOutTime);
 
     /** 출근 상태 기록 */
     AttendanceResponse markAttendanceStatus(Long userId,
                                            LocalDate date,
                                            AttendanceStatus attendanceStatus,
                                            boolean autoRecorded,
-                                           LocalDateTime checkInTime,
-                                           LocalDateTime checkOutTime);
+                                           Instant checkInTime,
+                                           Instant checkOutTime);
 
     /** 근무 상태 기록 */
     AttendanceResponse markWorkStatus(Long userId,
                                      LocalDate date,
                                      WorkStatus workStatus,
                                      boolean autoRecorded,
-                                     LocalDateTime checkInTime,
-                                     LocalDateTime checkOutTime);
+                                     Instant checkInTime,
+                                     Instant checkOutTime);
 
     /** 이번 주 근무 요약 */
     WeeklyWorkSummary getThisWeekSummary(Long userId);

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
@@ -506,7 +506,7 @@ public class WorkScheduleService {
                 
                 Schedule workSchedule = Schedule.builder()
                         .userId(userId)
-                        .title("근무일")
+                        .title(ScheduleType.WORK.getDescription())
                         .description(String.format("출근: %s, 퇴근: %s, 근무시간: %d시간 %d분", 
                                 startTime, endTime, 
                                 workPolicy.getWorkHours() != null ? workPolicy.getWorkHours() : 8,
@@ -561,7 +561,7 @@ public class WorkScheduleService {
                 
                 Schedule breakSchedule = Schedule.builder()
                         .userId(userId)
-                        .title("휴식 시간")
+                        .title(ScheduleType.RESTTIME.getDescription())
                         .description(String.format("휴게시간: %s ~ %s (%d분)", 
                                 workPolicy.getBreakStartTime(), breakEndTime,
                                 workPolicy.getBreakMinutes() != null ? workPolicy.getBreakMinutes() : 60))
@@ -569,7 +569,7 @@ public class WorkScheduleService {
                         .endDate(currentDate)
                         .startTime(workPolicy.getBreakStartTime())
                         .endTime(breakEndTime)
-                        .scheduleType(ScheduleType.WORK) // BREAK는 WORK 타입으로 처리
+                        .scheduleType(ScheduleType.RESTTIME)
                         .color("#ffc107")
                         .isAllDay(false)
                         .isRecurring(false)

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
@@ -175,7 +175,7 @@ public class WorkScheduleService {
             );
             
             if (hasConflict) {
-                throw new RuntimeException("Schedule conflict detected for the specified time period");
+                throw new RuntimeException("동일 시간대에 기존 스케줄이 존재합니다.");
             }
             
             // 3. 스케줄 생성
@@ -239,7 +239,7 @@ public class WorkScheduleService {
             );
             
             if (hasConflict) {
-                throw new RuntimeException("Schedule conflict detected for the specified time period");
+                throw new RuntimeException("동일 시간대에 기존 스케줄이 존재합니다.");
             }
             
             // 4. 스케줄 업데이트


### PR DESCRIPTION
## 이슈 번호

close #126 

## 작업 사항

- ScheduleType에 RESTTIME("휴게시간") 추가
- refactor: 휴게가 근무로 표시되던 문제 수정
- WorkScheduleService#createBreakTimeSchedules에서 제목을 ScheduleType.RESTTIME.getDescription()으로 변경
- scheduleType을 WORK → RESTTIME으로 수정
- FE의 enum 우선 표기 로직과 일치하도록 정합성 개선
- ScheduleType에 RESTTIME("휴게시간") 추가
- WorkScheduleService
- createWorkDaySchedules 제목을 ScheduleType.WORK.getDescription() 사용으로 변경(“근무일” 하드코딩 제거)
- createBreakTimeSchedules를 RESTTIME으로 생성하도록 수정(제목/타입/색상 정비)
- existsConflictingSchedule 호출 시 LocalTime → String 변환(requestDto.getStartTime().toString() 등)으로 시그니처 일치
- create/update/delete 스케줄 실패 시 원인 메시지 전파(throw new RuntimeException(e.getMessage(), e))
- WorkScheduleController
- @PreAuthorize에서 authentication.principal.userId → authentication.principal.id로 수정
- 스케줄 생성 실패 시 상세 메시지 응답("스케줄 생성 실패: " + e.getMessage())
- AttendanceController
- @PreAuthorize의 userId 참조를 authentication.principal.id로 통일
- 쿼리 파라미터 LocalDateTime → Instant로 스펙 변경(수신 시 변환 제거)
- AttendanceService(Interface/Impl)
- checkIn/checkOut/markAttendanceStatus/markWorkStatus 등 파라미터 LocalDateTime → Instant로 전환
- 내부 계산은 ZonedDateTime(Asia/Seoul)로 처리하고 DB 저장은 Instant(UTC)로 통일
- this week/auto checkout 등 시간 계산 로직 Instant.now() + ZoneId.of("Asia/Seoul") 사용
- 엔티티 시간 필드 일괄 전환(LocalDateTime → Instant)
- Schedule, WorkPolicy, AnnualLeave, WorkTimeAdjustment, LeaveRequest 등 createdAt/updatedAt(및 requestedAt/approvedAt) Instant로 변경
- 엔티티 라이프사이클 훅을 Instant.now()로 변경
- 로깅/검증
- 사용자 권한 체크 로직 개선(본인 또는 ADMIN)
- 고정/정책 기반 스케줄 생성 시 로깅 강화

## 스크린샷 (선택)


## 공유사항























