### PR TITLE
입사일 기준 연차 자동 부여 시스템 구현

### DIFF
--- a/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClient.java
+++ b/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClient.java
@@ -3,13 +3,19 @@ package com.hermes.userservice.client;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyRequestDto;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyUpdateDto;
+import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
 import com.hermes.api.common.ApiResult;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @FeignClient(name = "attendance-service", fallback = WorkPolicyServiceClientFallback.class)
 public interface WorkPolicyServiceClient {
 
     @GetMapping("/api/workpolicy/{id}")
     ApiResult<WorkPolicyResponseDto> getWorkPolicy(@PathVariable("id") Long id);
+    
+    @GetMapping("/api/annual-leaves/work-policies/{workPolicyId}")
+    ApiResult<List<AnnualLeaveResponseDto>> getAnnualLeavesByWorkPolicyId(@PathVariable("workPolicyId") Long workPolicyId);
 }

--- a/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClient.java
+++ b/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClient.java
@@ -1,10 +1,7 @@
 package com.hermes.userservice.client;
 
 import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
-import com.hermes.userservice.dto.workpolicy.WorkPolicyRequestDto;
-import com.hermes.userservice.dto.workpolicy.WorkPolicyUpdateDto;
 import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
-import com.hermes.api.common.ApiResult;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.*;
 
@@ -14,8 +11,8 @@ import java.util.List;
 public interface WorkPolicyServiceClient {
 
     @GetMapping("/api/workpolicy/{id}")
-    ApiResult<WorkPolicyResponseDto> getWorkPolicy(@PathVariable("id") Long id);
+    WorkPolicyResponseDto getWorkPolicy(@PathVariable("id") Long id);
     
     @GetMapping("/api/annual-leaves/work-policies/{workPolicyId}")
-    ApiResult<List<AnnualLeaveResponseDto>> getAnnualLeavesByWorkPolicyId(@PathVariable("workPolicyId") Long workPolicyId);
+    List<AnnualLeaveResponseDto> getAnnualLeavesByWorkPolicyId(@PathVariable("workPolicyId") Long workPolicyId);
 }

--- a/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClientFallback.java
+++ b/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClientFallback.java
@@ -4,8 +4,11 @@ import com.hermes.api.common.ApiResult;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyRequestDto;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyUpdateDto;
+import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+
+import java.util.List;
 
 @Slf4j
 @Component
@@ -14,6 +17,12 @@ public class WorkPolicyServiceClientFallback implements WorkPolicyServiceClient 
     @Override
     public ApiResult<WorkPolicyResponseDto> getWorkPolicy(Long id) {
         log.warn("attendance-service call failed - getWorkPolicy: {}", id);
+        return ApiResult.failure("Service Unavailable");
+    }
+    
+    @Override
+    public ApiResult<List<AnnualLeaveResponseDto>> getAnnualLeavesByWorkPolicyId(Long workPolicyId) {
+        log.warn("attendance-service call failed - getAnnualLeavesByWorkPolicyId: {}", workPolicyId);
         return ApiResult.failure("Service Unavailable");
     }
 }

--- a/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClientFallback.java
+++ b/user-service/src/main/java/com/hermes/userservice/client/WorkPolicyServiceClientFallback.java
@@ -1,9 +1,6 @@
 package com.hermes.userservice.client;
 
-import com.hermes.api.common.ApiResult;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
-import com.hermes.userservice.dto.workpolicy.WorkPolicyRequestDto;
-import com.hermes.userservice.dto.workpolicy.WorkPolicyUpdateDto;
 import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -15,14 +12,14 @@ import java.util.List;
 public class WorkPolicyServiceClientFallback implements WorkPolicyServiceClient {
 
     @Override
-    public ApiResult<WorkPolicyResponseDto> getWorkPolicy(Long id) {
+    public WorkPolicyResponseDto getWorkPolicy(Long id) {
         log.warn("attendance-service call failed - getWorkPolicy: {}", id);
-        return ApiResult.failure("Service Unavailable");
+        return null;
     }
     
     @Override
-    public ApiResult<List<AnnualLeaveResponseDto>> getAnnualLeavesByWorkPolicyId(Long workPolicyId) {
+    public List<AnnualLeaveResponseDto> getAnnualLeavesByWorkPolicyId(Long workPolicyId) {
         log.warn("attendance-service call failed - getAnnualLeavesByWorkPolicyId: {}", workPolicyId);
-        return ApiResult.failure("Service Unavailable");
+        return List.of();
     }
 }

--- a/user-service/src/main/java/com/hermes/userservice/dto/workpolicy/AnnualLeaveResponseDto.java
+++ b/user-service/src/main/java/com/hermes/userservice/dto/workpolicy/AnnualLeaveResponseDto.java
@@ -2,7 +2,7 @@ package com.hermes.userservice.dto.workpolicy;
 
 import lombok.*;
 
-import java.time.LocalDateTime;
+import java.time.Instant;
 
 @Getter
 @Setter
@@ -18,7 +18,7 @@ public class AnnualLeaveResponseDto {
     private Integer maxYears;
     private Integer leaveDays;
     private Integer holidayDays;
-    private String rangeDescription; // 범위 설명 (예: "0~1년차", "2~3년차")
-    private LocalDateTime createdAt;
-    private LocalDateTime updatedAt;
+    private String rangeDescription;
+    private Instant createdAt;
+    private Instant updatedAt;
 }

--- a/user-service/src/main/java/com/hermes/userservice/scheduler/VacationScheduler.java
+++ b/user-service/src/main/java/com/hermes/userservice/scheduler/VacationScheduler.java
@@ -1,0 +1,27 @@
+package com.hermes.userservice.scheduler;
+
+import com.hermes.userservice.service.VacationService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class VacationScheduler {
+
+    private final VacationService vacationService;
+
+    @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
+    public void grantVacationOnAnniversaries() {
+        log.info("연차 부여 스케줄러 실행 시작");
+        
+        try {
+            int grantedCount = vacationService.grantVacationForAllAnniversaries();
+            log.info("연차 부여 스케줄러 실행 완료: {}명에게 연차 부여", grantedCount);
+        } catch (Exception e) {
+            log.error("연차 부여 스케줄러 실행 실패", e);
+        }
+    }
+}

--- a/user-service/src/main/java/com/hermes/userservice/service/VacationService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/VacationService.java
@@ -1,0 +1,98 @@
+package com.hermes.userservice.service;
+
+import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
+import com.hermes.userservice.entity.User;
+import com.hermes.userservice.repository.UserRepository;
+import com.hermes.userservice.util.CareerCalculator;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class VacationService {
+
+    private final UserRepository userRepository;
+    private final WorkPolicyIntegrationService workPolicyIntegrationService;
+
+    public int grantVacationOnAnniversary(Long userId) {
+        log.info("연차 부여 시작: userId={}", userId);
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new RuntimeException("사용자를 찾을 수 없습니다: " + userId));
+        
+        LocalDate joinDate = user.getJoinDate();
+        if (joinDate == null) {
+            log.warn("입사일이 null입니다: userId={}", userId);
+            return 0;
+        }
+        
+        if (!CareerCalculator.isAnniversary(joinDate)) {
+            log.info("입사일이 아닙니다: userId={}, joinDate={}", userId, joinDate);
+            return 0;
+        }
+        
+        int careerYears = CareerCalculator.calculateCareerYears(joinDate);
+        int leaveDays = getLeaveDaysByCareerYears(user.getWorkPolicyId(), careerYears);
+        
+        if (leaveDays > 0) {
+            log.info("연차 부여 완료: userId={}, careerYears={}, leaveDays={}", userId, careerYears, leaveDays);
+        } else {
+            log.info("부여할 연차가 없습니다: userId={}, careerYears={}", userId, careerYears);
+        }
+        
+        return leaveDays;
+    }
+
+    public int grantVacationForAllAnniversaries() {
+        log.info("전체 사용자 연차 부여 시작");
+        
+        List<User> allUsers = userRepository.findAll();
+        int grantedCount = 0;
+        
+        for (User user : allUsers) {
+            try {
+                int leaveDays = grantVacationOnAnniversary(user.getId());
+                if (leaveDays > 0) {
+                    grantedCount++;
+                }
+            } catch (Exception e) {
+                log.error("사용자 연차 부여 실패: userId={}", user.getId(), e);
+            }
+        }
+        
+        log.info("전체 사용자 연차 부여 완료: 총 {}명에게 연차 부여", grantedCount);
+        return grantedCount;
+    }
+
+    private int getLeaveDaysByCareerYears(Long workPolicyId, int careerYears) {
+        if (workPolicyId == null) {
+            log.warn("근무정책 ID가 null입니다. 기본 휴가 일수 사용: careerYears={}", careerYears);
+            return CareerCalculator.calculateBasicLeaveDays(careerYears);
+        }
+        
+        try {
+            List<AnnualLeaveResponseDto> annualLeaves = workPolicyIntegrationService.getAnnualLeavesByWorkPolicyId(workPolicyId);
+            
+            for (AnnualLeaveResponseDto annualLeave : annualLeaves) {
+                if (annualLeave.getMinYears() <= careerYears && careerYears <= annualLeave.getMaxYears()) {
+                    log.debug("휴가 정책 매칭: careerYears={}, leaveDays={}", careerYears, annualLeave.getLeaveDays());
+                    return annualLeave.getLeaveDays();
+                }
+            }
+            
+            log.warn("경력년차에 맞는 휴가 정책을 찾을 수 없습니다: workPolicyId={}, careerYears={}", workPolicyId, careerYears);
+            return CareerCalculator.calculateBasicLeaveDays(careerYears);
+            
+        } catch (Exception e) {
+            log.error("휴가 정책 조회 실패: workPolicyId={}, careerYears={}", workPolicyId, careerYears, e);
+            return CareerCalculator.calculateBasicLeaveDays(careerYears);
+        }
+    }
+}

--- a/user-service/src/main/java/com/hermes/userservice/service/VacationService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/VacationService.java
@@ -77,22 +77,21 @@ public class VacationService {
             return CareerCalculator.calculateBasicLeaveDays(careerYears);
         }
         
-        try {
-            List<AnnualLeaveResponseDto> annualLeaves = workPolicyIntegrationService.getAnnualLeavesByWorkPolicyId(workPolicyId);
-            
-            for (AnnualLeaveResponseDto annualLeave : annualLeaves) {
-                if (annualLeave.getMinYears() <= careerYears && careerYears <= annualLeave.getMaxYears()) {
-                    log.debug("휴가 정책 매칭: careerYears={}, leaveDays={}", careerYears, annualLeave.getLeaveDays());
-                    return annualLeave.getLeaveDays();
-                }
-            }
-            
-            log.warn("경력년차에 맞는 휴가 정책을 찾을 수 없습니다: workPolicyId={}, careerYears={}", workPolicyId, careerYears);
-            return CareerCalculator.calculateBasicLeaveDays(careerYears);
-            
-        } catch (Exception e) {
-            log.error("휴가 정책 조회 실패: workPolicyId={}, careerYears={}", workPolicyId, careerYears, e);
+        List<AnnualLeaveResponseDto> annualLeaves = workPolicyIntegrationService.getAnnualLeavesByWorkPolicyId(workPolicyId);
+        
+        if (annualLeaves == null || annualLeaves.isEmpty()) {
+            log.warn("연차 정책을 찾을 수 없습니다: workPolicyId={}, careerYears={}", workPolicyId, careerYears);
             return CareerCalculator.calculateBasicLeaveDays(careerYears);
         }
+        
+        for (AnnualLeaveResponseDto annualLeave : annualLeaves) {
+            if (annualLeave.getMinYears() <= careerYears && careerYears <= annualLeave.getMaxYears()) {
+                log.debug("휴가 정책 매칭: careerYears={}, leaveDays={}", careerYears, annualLeave.getLeaveDays());
+                return annualLeave.getLeaveDays();
+            }
+        }
+        
+        log.warn("경력년차에 맞는 휴가 정책을 찾을 수 없습니다: workPolicyId={}, careerYears={}", workPolicyId, careerYears);
+        return CareerCalculator.calculateBasicLeaveDays(careerYears);
     }
 }

--- a/user-service/src/main/java/com/hermes/userservice/service/WorkPolicyIntegrationService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/WorkPolicyIntegrationService.java
@@ -4,6 +4,7 @@ import com.hermes.userservice.client.WorkPolicyServiceClient;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyRequestDto;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyUpdateDto;
+import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
 import com.hermes.userservice.entity.User;
 import com.hermes.userservice.exception.UserNotFoundException;
 import com.hermes.userservice.repository.UserRepository;
@@ -66,6 +67,30 @@ public class WorkPolicyIntegrationService {
         } catch (FeignException e) {
             log.warn("근무 정책 서비스가 사용 불가능합니다. workPolicyId={}, status={}", workPolicyId, e.status());
             return null;
+        }
+    }
+
+    /**
+     * 근무정책 ID로 연차 정보 목록을 조회합니다.
+     * @param workPolicyId 근무정책 ID
+     * @return 연차 정보 목록
+     */
+    public List<AnnualLeaveResponseDto> getAnnualLeavesByWorkPolicyId(Long workPolicyId) {
+        log.info("연차 정보 조회: workPolicyId={}", workPolicyId);
+        try {
+            ApiResult<List<AnnualLeaveResponseDto>> result = workPolicyServiceClient.getAnnualLeavesByWorkPolicyId(workPolicyId);
+            if ("SUCCESS".equals(result.getStatus())) {
+                return result.getData();
+            } else {
+                log.error("연차 정보 조회 실패: {}", result.getMessage());
+                return List.of();
+            }
+        } catch (FeignException.NotFound e) {
+            log.error("연차 정보를 찾을 수 없습니다. workPolicyId={}", workPolicyId, e);
+            return List.of();
+        } catch (FeignException e) {
+            log.warn("근무 정책 서비스가 사용 불가능합니다. workPolicyId={}, status={}", workPolicyId, e.status());
+            return List.of();
         }
     }
 

--- a/user-service/src/main/java/com/hermes/userservice/service/WorkPolicyIntegrationService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/WorkPolicyIntegrationService.java
@@ -8,7 +8,6 @@ import com.hermes.userservice.dto.workpolicy.AnnualLeaveResponseDto;
 import com.hermes.userservice.entity.User;
 import com.hermes.userservice.exception.UserNotFoundException;
 import com.hermes.userservice.repository.UserRepository;
-import feign.FeignException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -19,7 +18,6 @@ import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import java.util.stream.Collectors;
-import com.hermes.api.common.ApiResult;
 import org.springframework.stereotype.Component;
 
 @Slf4j
@@ -53,45 +51,12 @@ public class WorkPolicyIntegrationService {
 
     public WorkPolicyResponseDto getWorkPolicy(Long workPolicyId) {
         log.info("근무 정책 조회: workPolicyId={}", workPolicyId);
-        try {
-            ApiResult<WorkPolicyResponseDto> result = workPolicyServiceClient.getWorkPolicy(workPolicyId);
-            if ("SUCCESS".equals(result.getStatus())) {
-                return result.getData();
-            } else {
-                log.error("근무 정책 조회 실패: {}", result.getMessage());
-                return null;
-            }
-        } catch (FeignException.NotFound e) {
-            log.error("근무 정책을 찾을 수 없습니다. workPolicyId={}", workPolicyId, e);
-            return null;
-        } catch (FeignException e) {
-            log.warn("근무 정책 서비스가 사용 불가능합니다. workPolicyId={}, status={}", workPolicyId, e.status());
-            return null;
-        }
+        return workPolicyServiceClient.getWorkPolicy(workPolicyId);
     }
 
-    /**
-     * 근무정책 ID로 연차 정보 목록을 조회합니다.
-     * @param workPolicyId 근무정책 ID
-     * @return 연차 정보 목록
-     */
     public List<AnnualLeaveResponseDto> getAnnualLeavesByWorkPolicyId(Long workPolicyId) {
         log.info("연차 정보 조회: workPolicyId={}", workPolicyId);
-        try {
-            ApiResult<List<AnnualLeaveResponseDto>> result = workPolicyServiceClient.getAnnualLeavesByWorkPolicyId(workPolicyId);
-            if ("SUCCESS".equals(result.getStatus())) {
-                return result.getData();
-            } else {
-                log.error("연차 정보 조회 실패: {}", result.getMessage());
-                return List.of();
-            }
-        } catch (FeignException.NotFound e) {
-            log.error("연차 정보를 찾을 수 없습니다. workPolicyId={}", workPolicyId, e);
-            return List.of();
-        } catch (FeignException e) {
-            log.warn("근무 정책 서비스가 사용 불가능합니다. workPolicyId={}, status={}", workPolicyId, e.status());
-            return List.of();
-        }
+        return workPolicyServiceClient.getAnnualLeavesByWorkPolicyId(workPolicyId);
     }
 
     @Transactional(readOnly = true)

--- a/user-service/src/main/java/com/hermes/userservice/util/CareerCalculator.java
+++ b/user-service/src/main/java/com/hermes/userservice/util/CareerCalculator.java
@@ -1,0 +1,98 @@
+package com.hermes.userservice.util;
+
+import lombok.experimental.UtilityClass;
+import lombok.extern.slf4j.Slf4j;
+
+import java.time.LocalDate;
+import java.time.temporal.ChronoUnit;
+
+@UtilityClass
+@Slf4j
+public class CareerCalculator {
+
+    public static long calculateCareerDays(LocalDate joinDate) {
+        if (joinDate == null) {
+            log.warn("입사일이 null입니다.");
+            return 0;
+        }
+        
+        LocalDate today = LocalDate.now();
+        long careerDays = ChronoUnit.DAYS.between(joinDate, today);
+        
+        log.debug("경력일수 계산: 입사일={}, 오늘={}, 경력일수={}", joinDate, today, careerDays);
+        return Math.max(0, careerDays);
+    }
+
+    public static int calculateCareerYears(LocalDate joinDate) {
+        if (joinDate == null) {
+            log.warn("입사일이 null입니다.");
+            return 0;
+        }
+        
+        LocalDate today = LocalDate.now();
+        int careerYears = (int) ChronoUnit.YEARS.between(joinDate, today);
+        
+        log.debug("경력년차 계산: 입사일={}, 오늘={}, 경력년차={}", joinDate, today, careerYears);
+        return Math.max(0, careerYears);
+    }
+
+    public static long calculateCareerMonths(LocalDate joinDate) {
+        if (joinDate == null) {
+            log.warn("입사일이 null입니다.");
+            return 0;
+        }
+        
+        LocalDate today = LocalDate.now();
+        long careerMonths = ChronoUnit.MONTHS.between(joinDate, today);
+        
+        log.debug("경력개월수 계산: 입사일={}, 오늘={}, 경력개월수={}", joinDate, today, careerMonths);
+        return Math.max(0, careerMonths);
+    }
+
+    public static boolean isAnniversary(LocalDate joinDate) {
+        if (joinDate == null) {
+            return false;
+        }
+        
+        LocalDate today = LocalDate.now();
+        boolean isAnniversary = joinDate.getMonth() == today.getMonth() && 
+                               joinDate.getDayOfMonth() == today.getDayOfMonth();
+        
+        log.debug("입사일 확인: 입사일={}, 오늘={}, 입사일={}", joinDate, today, isAnniversary);
+        return isAnniversary;
+    }
+
+    public static int calculateBasicLeaveDays(int careerYears) {
+        if (careerYears < 0) {
+            return 0;
+        }
+        
+        int leaveDays;
+        if (careerYears == 0) {
+            leaveDays = 11;
+        } else if (careerYears < 2) {
+            leaveDays = 15;
+        } else if (careerYears < 3) {
+            leaveDays = 16;
+        } else if (careerYears < 4) {
+            leaveDays = 18;
+        } else if (careerYears < 5) {
+            leaveDays = 20;
+        } else if (careerYears < 6) {
+            leaveDays = 21;
+        } else if (careerYears < 7) {
+            leaveDays = 22;
+        } else if (careerYears < 8) {
+            leaveDays = 23;
+        } else if (careerYears < 9) {
+            leaveDays = 24;
+        } else if (careerYears < 10) {
+            leaveDays = 25;
+        } else {
+            leaveDays = 25;
+        }
+        
+        log.debug("기본 휴가 일수 계산: 경력년차={}, 휴가일수={}", careerYears, leaveDays);
+        return leaveDays;
+    }
+}


### PR DESCRIPTION
## 이슈 번호
N/A

## 작업 사항

### ✨ 주요 기능

#### 1. **CareerCalculator** (유틸리티 클래스)
- 경력일수, 년차, 개월수 계산
- 입사일 확인
- 기본 휴가 일수 계산 로직

#### 2. **VacationService** (휴가 부여 로직)
- 입사일 확인 및 연차 부여
- 경력년차에 따른 휴가 일수 결정
- 전체 사용자 대상 휴가 부여

#### 3. **VacationScheduler** (자동 스케줄러)
- 매일 자정 실행 (`@Scheduled(cron = "0 0 0 * * ?")`)
- 입사일 확인 및 연차 자동 부여

#### 4. **WorkPolicyIntegrationService** (API 연동)
- 연차 정보 조회 메서드 추가
- Feign 클라이언트를 통한 API 호출 처리

#### 5. **WorkPolicyServiceClient** (Feign 클라이언트)
- `getAnnualLeavesByWorkPolicyId` 메서드 추가
- `attendance-service`의 연차 정책 API 호출

### 🔄 동작 흐름

#### **실시간 경력 계산**
1. 사용자 정보 조회 API 호출
2. `CareerCalculator`로 경력 정보 계산
3. 필요시 경력 정보를 로그로 출력

#### **자동 연차 부여**
1. 매일 자정 스케줄러 실행
2. 모든 사용자 조회
3. 각 사용자의 입사일 확인
4. 입사일인 경우 경력년차 계산
5. `attendance-service`에서 연차 정책 조회
6. 해당하는 휴가 일수 부여 (현재는 로그 출력)

### 연동 상태

#### ✅ 이미 연동된 부분들:
- WorkPolicy 연동 (근무정책 정보 조회)
- AnnualLeave 연동 (연차 정책 조회)
- User 정보 연동 (사용자 정보 조회)

#### ❌ 아직 연동되지 않은 부분:
- 실제 휴가 부여 API (attendance-service에 추가 요청 필요)

## 스크린샷 (선택)

N/A


## 공유사항

### 📝 TODO
N/A





















