### PR TITLE
연차 일수 부여, 차감 및 조회 로직 생성

### DIFF
--- a/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
@@ -3,18 +3,14 @@ package com.hermes.attendanceservice.client;
 import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestHeader;
 
 import java.util.Map;
 
 @FeignClient(name = "user-service", url = "${user-service.url:http://localhost:8081}")
 public interface UserServiceClient {
     
-    @GetMapping("/api/users/{userId}/simple")
-    Map<String, Object> getUserById(@PathVariable("userId") Long userId);
-    
     @GetMapping("/api/users/{userId}")
-    Map<String, Object> getUserById(@PathVariable("userId") Long userId, @RequestHeader(value = "Authorization", required = false) String authorization);
+    Map<String, Object> getUserById(@PathVariable("userId") Long userId);
     
     @GetMapping("/api/users/count")
     Map<String, Object> getTotalEmployees();

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/config/FeignClientConfig.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/config/FeignClientConfig.java
@@ -1,0 +1,47 @@
+package com.hermes.attendanceservice.config;
+
+import feign.RequestInterceptor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+@Slf4j
+@Configuration
+public class FeignClientConfig {
+    
+    @Bean
+    public RequestInterceptor feignRequestInterceptor() {
+        return requestTemplate -> {
+            try {
+                // 현재 요청의 Authorization 헤더를 그대로 전달
+                String authHeader = getCurrentRequestAuthHeader();
+                if (authHeader != null) {
+                    requestTemplate.header("Authorization", authHeader);
+                    log.debug("Feign Client에 Authorization 헤더 추가: {}", 
+                             authHeader.substring(0, Math.min(20, authHeader.length())) + "...");
+                } else {
+                    log.warn("현재 요청에서 Authorization 헤더를 찾을 수 없음");
+                }
+            } catch (Exception e) {
+                log.error("Feign Client Authorization 헤더 추가 실패: {}", e.getMessage(), e);
+            }
+        };
+    }
+    
+    private String getCurrentRequestAuthHeader() {
+        try {
+            ServletRequestAttributes attributes = (ServletRequestAttributes) RequestContextHolder.getRequestAttributes();
+            if (attributes != null) {
+                HttpServletRequest request = attributes.getRequest();
+                return request.getHeader("Authorization");
+            }
+        } catch (Exception e) {
+            log.warn("Authorization 헤더 추출 실패: {}", e.getMessage());
+        }
+        return null;
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/config/SecurityConfig.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/config/SecurityConfig.java
@@ -16,8 +16,8 @@ public class SecurityConfig extends BaseSecurityConfig {
     protected void configureAuthorization(
         AuthorizeHttpRequestsConfigurer<HttpSecurity>.AuthorizationManagerRequestMatcherRegistry auth
     ) {
-        // BaseSecurityConfig에서 설정되지 않은 경로들만 추가
-        auth.requestMatchers("/api-docs/**").permitAll();  // application.yml에서 설정한 경로
+        // BaseSecurityConfig에서 이미 /v3/api-docs/**와 /swagger-ui/**를 허용하므로
+        // attendance-service API들만 추가로 허용
         auth.requestMatchers("/api/**").permitAll();       // attendance-service API들
     }
 }

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/EmployeeLeaveBalanceController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/EmployeeLeaveBalanceController.java
@@ -1,0 +1,157 @@
+package com.hermes.attendanceservice.controller;
+
+import com.hermes.api.common.ApiResult;
+import com.hermes.attendanceservice.dto.leave.EmployeeLeaveBalanceResponseDto;
+import com.hermes.attendanceservice.dto.leave.EmployeeLeaveBalanceSummaryDto;
+import com.hermes.attendanceservice.entity.leave.LeaveType;
+import com.hermes.attendanceservice.service.leave.EmployeeLeaveBalanceService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Tag(name = "직원 연차 잔액 관리", description = "직원별 연차 잔액 조회, 부여, 사용, 복구 등을 관리하는 API")
+@RestController
+@RequestMapping("/api/leave-balance")
+@RequiredArgsConstructor
+@Slf4j
+public class EmployeeLeaveBalanceController {
+    
+    private final EmployeeLeaveBalanceService employeeLeaveBalanceService;
+    
+    @Operation(summary = "연차 자동 부여", description = "직원의 근무년수에 따라 연차를 자동으로 부여합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 부여 성공", 
+                    content = @Content(schema = @Schema(implementation = ApiResult.class))),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (직원 정보 없음, 근무정책 없음 등)")
+    })
+    @PostMapping("/grant-annual/{employeeId}")
+    public ResponseEntity<ApiResult<List<EmployeeLeaveBalanceResponseDto>>> grantAnnualLeave(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId,
+            @Parameter(description = "기준일 (기본값: 오늘)", example = "2024-01-01") 
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate baseDate) {
+        
+        LocalDate grantDate = baseDate != null ? baseDate : LocalDate.now();
+        log.info("연차 자동 부여 요청: employeeId={}, baseDate={}", employeeId, grantDate);
+        
+        List<EmployeeLeaveBalanceResponseDto> responses = employeeLeaveBalanceService.grantAnnualLeave(employeeId, grantDate);
+        return ResponseEntity.ok(ApiResult.success(responses));
+    }
+    
+    @Operation(summary = "특정 타입 잔여 연차 조회", description = "직원의 특정 연차 타입별 잔여 일수를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "직원 또는 연차 정보를 찾을 수 없음")
+    })
+    @GetMapping("/remaining/{employeeId}")
+    public ResponseEntity<ApiResult<Integer>> getRemainingLeave(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId,
+            @Parameter(description = "연차 타입", required = true, schema = @Schema(implementation = LeaveType.class)) 
+            @RequestParam LeaveType leaveType) {
+        
+        Integer remainingDays = employeeLeaveBalanceService.getRemainingLeave(employeeId, leaveType);
+        return ResponseEntity.ok(ApiResult.success(remainingDays));
+    }
+    
+    @Operation(summary = "전체 잔여 연차 조회", description = "직원의 모든 연차 타입을 합한 총 잔여 일수를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "직원 정보를 찾을 수 없음")
+    })
+    @GetMapping("/remaining-total/{employeeId}")
+    public ResponseEntity<ApiResult<Integer>> getTotalRemainingLeave(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId) {
+        Integer totalRemainingDays = employeeLeaveBalanceService.getTotalRemainingLeave(employeeId);
+        return ResponseEntity.ok(ApiResult.success(totalRemainingDays));
+    }
+    
+    @Operation(summary = "연차 잔액 상세 조회", description = "직원의 연차 타입별 상세 잔액 정보를 조회합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "직원 정보를 찾을 수 없음")
+    })
+    @GetMapping("/details/{employeeId}")
+    public ResponseEntity<ApiResult<List<EmployeeLeaveBalanceResponseDto>>> getLeaveBalances(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId) {
+        
+        List<EmployeeLeaveBalanceResponseDto> balances = employeeLeaveBalanceService.getLeaveBalances(employeeId);
+        return ResponseEntity.ok(ApiResult.success(balances));
+    }
+    
+    @Operation(summary = "연차 잔액 요약 조회", description = "직원의 연차 사용 현황을 요약하여 조회합니다. (총 부여, 사용, 잔여, 사용률 등)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "조회 성공"),
+        @ApiResponse(responseCode = "404", description = "직원 정보를 찾을 수 없음")
+    })
+    @GetMapping("/summary/{employeeId}")
+    public ResponseEntity<ApiResult<EmployeeLeaveBalanceSummaryDto>> getLeaveBalanceSummary(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId) {
+        
+        EmployeeLeaveBalanceSummaryDto summary = employeeLeaveBalanceService.getLeaveBalanceSummary(employeeId);
+        return ResponseEntity.ok(ApiResult.success(summary));
+    }
+    
+    @Operation(summary = "연차 초기화 및 재부여", description = "특정 직원의 기존 연차를 삭제하고 새로운 연차를 부여합니다. (년차 변경 시 사용)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "초기화 및 재부여 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (직원 정보 없음, 근무정책 없음 등)")
+    })
+    @PostMapping("/reset/{employeeId}")
+    public ResponseEntity<ApiResult<List<EmployeeLeaveBalanceResponseDto>>> resetAndGrantAnnualLeave(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId,
+            @Parameter(description = "새로운 연차 부여일 (기본값: 오늘)", example = "2024-01-01")
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate newGrantDate) {
+        
+        LocalDate grantDate = newGrantDate != null ? newGrantDate : LocalDate.now();
+        log.info("직원 연차 초기화 및 재부여 요청: employeeId={}, newGrantDate={}", employeeId, grantDate);
+        
+        List<EmployeeLeaveBalanceResponseDto> responses = employeeLeaveBalanceService.resetAndGrantAnnualLeave(employeeId, grantDate);
+        return ResponseEntity.ok(ApiResult.success(responses));
+    }
+    
+    @Operation(summary = "연차 복구", description = "연차 신청 취소 시 사용한 연차를 다시 복구합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 복구 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (복구할 연차보다 사용한 연차가 적음)")
+    })
+    @PostMapping("/restore/{employeeId}")
+    public ResponseEntity<ApiResult<String>> restoreLeave(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId,
+            @Parameter(description = "연차 타입", required = true, schema = @Schema(implementation = LeaveType.class)) 
+            @RequestParam LeaveType leaveType,
+            @Parameter(description = "복구할 연차 일수", required = true, example = "3") 
+            @RequestParam Integer days) {
+        
+        log.info("연차 복구 요청: employeeId={}, leaveType={}, days={}", employeeId, leaveType, days);
+        
+        employeeLeaveBalanceService.restoreLeave(employeeId, leaveType, days);
+        return ResponseEntity.ok(ApiResult.success("연차 복구가 완료되었습니다."));
+    }
+    
+    @Operation(summary = "전체 직원 연차 초기화", description = "모든 직원의 연차를 초기화하고 재부여합니다. (관리자 전용 - 신년도 시작 시 사용)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "전체 초기화 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/reset-all")
+    public ResponseEntity<ApiResult<String>> resetAllEmployeesAnnualLeave(
+            @Parameter(description = "새로운 연차 부여일", required = true, example = "2024-01-01")
+            @RequestParam @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) LocalDate newGrantDate) {
+        
+        log.info("모든 직원 연차 초기화 및 재부여 요청: newGrantDate={}", newGrantDate);
+        
+        employeeLeaveBalanceService.resetAllEmployeesAnnualLeave(newGrantDate);
+        return ResponseEntity.ok(ApiResult.success("모든 직원의 연차 초기화 및 재부여가 완료되었습니다."));
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/leave/EmployeeLeaveBalanceResponseDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/leave/EmployeeLeaveBalanceResponseDto.java
@@ -1,0 +1,50 @@
+package com.hermes.attendanceservice.dto.leave;
+
+import com.hermes.attendanceservice.entity.leave.LeaveType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Schema(description = "직원 연차 잔액 응답 DTO")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmployeeLeaveBalanceResponseDto {
+    
+    @Schema(description = "연차 잔액 ID", example = "1")
+    private Long id;
+    
+    @Schema(description = "직원 ID", example = "123")
+    private Long employeeId;
+    
+    @Schema(description = "연차 타입", example = "BASIC_ANNUAL")
+    private LeaveType leaveType;
+    
+    @Schema(description = "연차 타입 한글명", example = "기본 연차")
+    private String leaveTypeName;
+    
+    @Schema(description = "총 부여된 연차 일수", example = "15")
+    private Integer totalLeaveDays;
+    
+    @Schema(description = "사용한 연차 일수", example = "3")
+    private Integer usedLeaveDays;
+    
+    @Schema(description = "잔여 연차 일수", example = "12")
+    private Integer remainingDays;
+    
+    @Schema(description = "근무년수", example = "2")
+    private Integer workYears;
+    
+    @Schema(description = "연차 사용률 (0.0 ~ 1.0)", example = "0.2")
+    private Double usageRate;
+    
+    @Schema(description = "생성일시")
+    private Instant createdAt;
+    
+    @Schema(description = "수정일시")
+    private Instant updatedAt;
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/dto/leave/EmployeeLeaveBalanceSummaryDto.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/dto/leave/EmployeeLeaveBalanceSummaryDto.java
@@ -1,0 +1,42 @@
+package com.hermes.attendanceservice.dto.leave;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+import java.util.List;
+
+@Schema(description = "직원 연차 잔액 요약 DTO")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmployeeLeaveBalanceSummaryDto {
+    
+    @Schema(description = "직원 ID", example = "123")
+    private Long employeeId;
+    
+    @Schema(description = "전체 잔여 연차 일수", example = "12")
+    private Integer totalRemainingDays;
+    
+    @Schema(description = "전체 사용한 연차 일수", example = "3")
+    private Integer totalUsedDays;
+    
+    @Schema(description = "전체 부여받은 연차 일수", example = "15")
+    private Integer totalGrantedDays;
+    
+    @Schema(description = "연차 타입별 상세 정보")
+    private List<EmployeeLeaveBalanceResponseDto> leaveBalances;
+    
+    @Schema(description = "기본 연차 잔여 일수", example = "10")
+    private Integer basicAnnualRemaining;
+    
+    @Schema(description = "보상 연차 잔여 일수", example = "2")
+    private Integer compensationAnnualRemaining;
+    
+    @Schema(description = "특별 연차 잔여 일수", example = "0")
+    private Integer specialAnnualRemaining;
+    
+    @Schema(description = "전체 연차 사용률 (0.0 ~ 1.0)", example = "0.2")
+    private Double overallUsageRate;
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/entity/leave/EmployeeLeaveBalance.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/entity/leave/EmployeeLeaveBalance.java
@@ -1,0 +1,96 @@
+package com.hermes.attendanceservice.entity.leave;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+@Entity
+@Table(name = "employee_leave_balance")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class EmployeeLeaveBalance {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @Column(name = "employee_id", nullable = false)
+    private Long employeeId; // 직원 ID
+    
+    @Enumerated(EnumType.STRING)
+    @Column(name = "leave_type", nullable = false)
+    private LeaveType leaveType; // 연차 종류 (기본연차, 보상연차, 특별연차)
+    
+    @Column(name = "total_leave_days", nullable = false)
+    private Integer totalLeaveDays; // 총 부여된 연차 일수
+    
+    @Column(name = "used_leave_days", nullable = false)
+    @Builder.Default
+    private Integer usedLeaveDays = 0; // 사용한 연차 일수
+    
+    @Column(name = "remaining_days", nullable = false)
+    private Integer remainingDays; // 잔여 연차 일수
+    
+    @Column(name = "work_years", nullable = false)
+    private Integer workYears; // 근무년수 (연차 부여 시점의 년차)
+    
+    @Column(name = "created_at")
+    private Instant createdAt;
+    
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+    
+    @PrePersist
+    protected void onCreate() {
+        createdAt = Instant.now();
+        updatedAt = Instant.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updatedAt = Instant.now();
+    }
+    
+    /**
+     * 연차 사용 (차감)
+     */
+    public void useLeave(Integer days) {
+        if (days <= 0) {
+            throw new IllegalArgumentException("사용할 연차 일수는 0보다 커야 합니다.");
+        }
+        if (days > remainingDays) {
+            throw new IllegalArgumentException("잔여 연차가 부족합니다. 잔여: " + remainingDays + "일, 요청: " + days + "일");
+        }
+        
+        this.usedLeaveDays += days;
+        this.remainingDays -= days;
+    }
+    
+    /**
+     * 연차 복구 (취소 시)
+     */
+    public void restoreLeave(Integer days) {
+        if (days <= 0) {
+            throw new IllegalArgumentException("복구할 연차 일수는 0보다 커야 합니다.");
+        }
+        if (usedLeaveDays < days) {
+            throw new IllegalArgumentException("복구할 수 없습니다. 사용한 연차: " + usedLeaveDays + "일, 복구 요청: " + days + "일");
+        }
+        
+        this.usedLeaveDays -= days;
+        this.remainingDays += days;
+    }
+    
+    /**
+     * 연차 사용률 계산 (0.0 ~ 1.0)
+     */
+    public double getUsageRate() {
+        if (totalLeaveDays == 0) return 0.0;
+        return (double) usedLeaveDays / totalLeaveDays;
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/repository/leave/EmployeeLeaveBalanceRepository.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/repository/leave/EmployeeLeaveBalanceRepository.java
@@ -1,0 +1,53 @@
+package com.hermes.attendanceservice.repository.leave;
+
+import com.hermes.attendanceservice.entity.leave.EmployeeLeaveBalance;
+import com.hermes.attendanceservice.entity.leave.LeaveType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface EmployeeLeaveBalanceRepository extends JpaRepository<EmployeeLeaveBalance, Long> {
+    
+    /**
+     * 직원 ID로 모든 연차 잔액 조회
+     */
+    List<EmployeeLeaveBalance> findByEmployeeId(Long employeeId);
+    
+    /**
+     * 직원 ID와 연차 타입으로 연차 잔액 조회
+     */
+    Optional<EmployeeLeaveBalance> findByEmployeeIdAndLeaveType(Long employeeId, LeaveType leaveType);
+    
+
+    
+    /**
+     * 직원 ID와 연차 타입으로 총 잔여 연차 계산
+     */
+    @Query("SELECT COALESCE(SUM(elb.remainingDays), 0) FROM EmployeeLeaveBalance elb WHERE elb.employeeId = :employeeId AND elb.leaveType = :leaveType")
+    Integer calculateTotalRemainingDays(@Param("employeeId") Long employeeId, 
+                                       @Param("leaveType") LeaveType leaveType);
+    
+    /**
+     * 직원 ID로 모든 타입의 총 잔여 연차 계산
+     */
+    @Query("SELECT COALESCE(SUM(elb.remainingDays), 0) FROM EmployeeLeaveBalance elb WHERE elb.employeeId = :employeeId")
+    Integer calculateTotalRemainingDaysByEmployeeId(@Param("employeeId") Long employeeId);
+    
+
+    
+    /**
+     * 특정 직원의 특정 연차 타입 삭제 (년차 초기화 시 사용)
+     */
+    void deleteByEmployeeIdAndLeaveType(Long employeeId, LeaveType leaveType);
+    
+    /**
+     * 특정 직원의 모든 연차 잔액 삭제 (년차 초기화 시 사용)
+     */
+    void deleteByEmployeeId(Long employeeId);
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/leave/EmployeeLeaveBalanceService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/leave/EmployeeLeaveBalanceService.java
@@ -1,0 +1,56 @@
+package com.hermes.attendanceservice.service.leave;
+
+import com.hermes.attendanceservice.dto.leave.EmployeeLeaveBalanceResponseDto;
+import com.hermes.attendanceservice.dto.leave.EmployeeLeaveBalanceSummaryDto;
+import com.hermes.attendanceservice.entity.leave.LeaveType;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public interface EmployeeLeaveBalanceService {
+    
+    /**
+     * 직원에게 연차 자동 부여 (입사일/승진일 기준)
+     */
+    List<EmployeeLeaveBalanceResponseDto> grantAnnualLeave(Long employeeId, LocalDate baseDate);
+    
+    /**
+     * 연차 사용 (차감)
+     */
+    void useLeave(Long employeeId, LeaveType leaveType, Integer days);
+    
+    /**
+     * 연차 복구 (취소 시)
+     */
+    void restoreLeave(Long employeeId, LeaveType leaveType, Integer days);
+    
+    /**
+     * 직원의 특정 타입 잔여 연차 조회
+     */
+    Integer getRemainingLeave(Long employeeId, LeaveType leaveType);
+    
+    /**
+     * 직원의 모든 타입 총 잔여 연차 조회
+     */
+    Integer getTotalRemainingLeave(Long employeeId);
+    
+    /**
+     * 직원의 연차 잔액 상세 조회
+     */
+    List<EmployeeLeaveBalanceResponseDto> getLeaveBalances(Long employeeId);
+    
+    /**
+     * 직원의 연차 잔액 요약 조회
+     */
+    EmployeeLeaveBalanceSummaryDto getLeaveBalanceSummary(Long employeeId);
+    
+    /**
+     * 특정 직원의 연차 초기화 및 재부여
+     */
+    List<EmployeeLeaveBalanceResponseDto> resetAndGrantAnnualLeave(Long employeeId, LocalDate newGrantDate);
+    
+    /**
+     * 모든 직원의 연차 초기화 및 재부여 
+     */
+    void resetAllEmployeesAnnualLeave(LocalDate newGrantDate);
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/leave/EmployeeLeaveBalanceServiceImpl.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/leave/EmployeeLeaveBalanceServiceImpl.java
@@ -1,0 +1,256 @@
+package com.hermes.attendanceservice.service.leave;
+
+import com.hermes.attendanceservice.dto.leave.EmployeeLeaveBalanceResponseDto;
+import com.hermes.attendanceservice.dto.leave.EmployeeLeaveBalanceSummaryDto;
+import com.hermes.attendanceservice.entity.leave.EmployeeLeaveBalance;
+import com.hermes.attendanceservice.entity.leave.LeaveType;
+import com.hermes.attendanceservice.entity.workpolicy.AnnualLeave;
+import com.hermes.attendanceservice.repository.leave.EmployeeLeaveBalanceRepository;
+import com.hermes.attendanceservice.repository.workpolicy.AnnualLeaveRepository;
+import com.hermes.attendanceservice.client.UserServiceClient;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class EmployeeLeaveBalanceServiceImpl implements EmployeeLeaveBalanceService {
+    
+    private final EmployeeLeaveBalanceRepository employeeLeaveBalanceRepository;
+    private final AnnualLeaveRepository annualLeaveRepository;
+    private final UserServiceClient userServiceClient;
+    
+    @Override
+    public List<EmployeeLeaveBalanceResponseDto> grantAnnualLeave(Long employeeId, LocalDate baseDate) {
+        log.info("연차 자동 부여 시작: employeeId={}, baseDate={}", employeeId, baseDate);
+        
+        // 1. 직원 정보 조회
+        Map<String, Object> user = userServiceClient.getUserById(employeeId);
+        if (user == null) {
+            throw new IllegalArgumentException("존재하지 않는 직원입니다: " + employeeId);
+        }
+        
+        // 2. 근무년수 조회 (user-service에서 계산된 값)
+        Integer workYears = (Integer) user.get("workYears");
+        if (workYears == null) {
+            // 임시: workYears가 없으면 기본값 1년으로 설정 (향후 user-service에서 제공해야 함)
+            workYears = 1;
+            log.warn("직원의 근무년수 정보를 찾을 수 없어 기본값 1년으로 설정합니다: employeeId={}", employeeId);
+        }
+        log.info("조회된 근무년수: {}년", workYears);
+        
+        // 3. 직원의 근무정책 조회 및 연차 규정 가져오기
+        Long workPolicyId = (Long) user.get("workPolicyId");
+        if (workPolicyId == null) {
+            throw new IllegalArgumentException("직원에게 근무정책이 할당되지 않았습니다: " + employeeId);
+        }
+        
+        List<AnnualLeave> annualLeaves = annualLeaveRepository.findByWorkPolicyId(workPolicyId);
+        if (annualLeaves.isEmpty()) {
+            throw new IllegalArgumentException("근무정책에 연차 규정이 없습니다: " + workPolicyId);
+        }
+        
+        // 4. 해당 근무년수에 맞는 연차 규정 찾기 및 부여
+        List<EmployeeLeaveBalance> grantedLeaves = new ArrayList<>();
+        
+        for (AnnualLeave annualLeave : annualLeaves) {
+            if (annualLeave.isInRange(workYears)) {
+                // 기본 연차로 부여 (실제로는 연차 타입 매핑 로직 필요)
+                LeaveType leaveType = mapToLeaveType(annualLeave.getName());
+                
+                EmployeeLeaveBalance leaveBalance = EmployeeLeaveBalance.builder()
+                        .employeeId(employeeId)
+                        .leaveType(leaveType)
+                        .totalLeaveDays(annualLeave.getLeaveDays())
+                        .remainingDays(annualLeave.getLeaveDays())
+                        .usedLeaveDays(0)
+                        .workYears(workYears)
+                        .build();
+                
+                grantedLeaves.add(leaveBalance);
+                log.info("연차 부여: type={}, days={}", leaveType, annualLeave.getLeaveDays());
+            }
+        }
+        
+        if (grantedLeaves.isEmpty()) {
+            log.warn("해당 근무년수에 맞는 연차 규정이 없습니다: workYears={}", workYears);
+            return new ArrayList<>();
+        }
+        
+        List<EmployeeLeaveBalance> savedLeaves = employeeLeaveBalanceRepository.saveAll(grantedLeaves);
+        log.info("연차 자동 부여 완료: employeeId={}, count={}", employeeId, savedLeaves.size());
+        
+        return savedLeaves.stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    public void useLeave(Long employeeId, LeaveType leaveType, Integer days) {
+        log.info("연차 사용 시작: employeeId={}, leaveType={}, days={}", employeeId, leaveType, days);
+        
+        Optional<EmployeeLeaveBalance> balanceOpt = employeeLeaveBalanceRepository
+                .findByEmployeeIdAndLeaveType(employeeId, leaveType);
+        
+        if (balanceOpt.isEmpty()) {
+            throw new IllegalArgumentException("사용 가능한 연차가 없습니다: employeeId=" + employeeId + ", leaveType=" + leaveType);
+        }
+        
+        EmployeeLeaveBalance balance = balanceOpt.get();
+        balance.useLeave(days);
+        
+        employeeLeaveBalanceRepository.save(balance);
+        log.info("연차 사용 완료: 잔여 연차={}", balance.getRemainingDays());
+    }
+    
+    @Override
+    public void restoreLeave(Long employeeId, LeaveType leaveType, Integer days) {
+        log.info("연차 복구 시작: employeeId={}, leaveType={}, days={}", employeeId, leaveType, days);
+        
+        Optional<EmployeeLeaveBalance> balanceOpt = employeeLeaveBalanceRepository
+                .findByEmployeeIdAndLeaveType(employeeId, leaveType);
+        
+        if (balanceOpt.isEmpty()) {
+            throw new IllegalArgumentException("연차 잔액이 없습니다: employeeId=" + employeeId + ", leaveType=" + leaveType);
+        }
+        
+        EmployeeLeaveBalance balance = balanceOpt.get();
+        balance.restoreLeave(days);
+        
+        employeeLeaveBalanceRepository.save(balance);
+        log.info("연차 복구 완료: 잔여 연차={}", balance.getRemainingDays());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public Integer getRemainingLeave(Long employeeId, LeaveType leaveType) {
+        return employeeLeaveBalanceRepository.calculateTotalRemainingDays(employeeId, leaveType);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public Integer getTotalRemainingLeave(Long employeeId) {
+        return employeeLeaveBalanceRepository.calculateTotalRemainingDaysByEmployeeId(employeeId);
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public List<EmployeeLeaveBalanceResponseDto> getLeaveBalances(Long employeeId) {
+        List<EmployeeLeaveBalance> balances = employeeLeaveBalanceRepository.findByEmployeeId(employeeId);
+        return balances.stream()
+                .map(this::convertToResponseDto)
+                .collect(Collectors.toList());
+    }
+    
+    @Override
+    @Transactional(readOnly = true)
+    public EmployeeLeaveBalanceSummaryDto getLeaveBalanceSummary(Long employeeId) {
+        List<EmployeeLeaveBalance> balances = employeeLeaveBalanceRepository.findByEmployeeId(employeeId);
+        
+        int totalRemaining = balances.stream().mapToInt(EmployeeLeaveBalance::getRemainingDays).sum();
+        int totalUsed = balances.stream().mapToInt(EmployeeLeaveBalance::getUsedLeaveDays).sum();
+        int totalGranted = balances.stream().mapToInt(EmployeeLeaveBalance::getTotalLeaveDays).sum();
+        
+        // 타입별 잔여 연차
+        int basicRemaining = balances.stream()
+                .filter(b -> b.getLeaveType() == LeaveType.BASIC_ANNUAL)
+                .mapToInt(EmployeeLeaveBalance::getRemainingDays).sum();
+        
+        int compensationRemaining = balances.stream()
+                .filter(b -> b.getLeaveType() == LeaveType.COMPENSATION_ANNUAL)
+                .mapToInt(EmployeeLeaveBalance::getRemainingDays).sum();
+        
+        int specialRemaining = balances.stream()
+                .filter(b -> b.getLeaveType() == LeaveType.SPECIAL_ANNUAL)
+                .mapToInt(EmployeeLeaveBalance::getRemainingDays).sum();
+        
+        double overallUsageRate = totalGranted > 0 ? (double) totalUsed / totalGranted : 0.0;
+        
+        return EmployeeLeaveBalanceSummaryDto.builder()
+                .employeeId(employeeId)
+                .totalRemainingDays(totalRemaining)
+                .totalUsedDays(totalUsed)
+                .totalGrantedDays(totalGranted)
+                .leaveBalances(balances.stream().map(this::convertToResponseDto).collect(Collectors.toList()))
+                .basicAnnualRemaining(basicRemaining)
+                .compensationAnnualRemaining(compensationRemaining)
+                .specialAnnualRemaining(specialRemaining)
+                .overallUsageRate(overallUsageRate)
+                .build();
+    }
+    
+    @Override
+    public List<EmployeeLeaveBalanceResponseDto> resetAndGrantAnnualLeave(Long employeeId, LocalDate newGrantDate) {
+        log.info("직원 연차 초기화 및 재부여 시작: employeeId={}, newGrantDate={}", employeeId, newGrantDate);
+        
+        // 1. 기존 연차 잔액 삭제
+        employeeLeaveBalanceRepository.deleteByEmployeeId(employeeId);
+        log.info("기존 연차 잔액 삭제 완료: employeeId={}", employeeId);
+        
+        // 2. 새로운 연차 부여
+        return grantAnnualLeave(employeeId, newGrantDate);
+    }
+    
+    @Override
+    public void resetAllEmployeesAnnualLeave(LocalDate newGrantDate) {
+        log.info("모든 직원 연차 초기화 및 재부여 시작: newGrantDate={}", newGrantDate);
+        
+        // 1. 모든 연차 잔액 삭제
+        employeeLeaveBalanceRepository.deleteAll();
+        
+        // 2. 모든 활성 직원에게 연차 재부여 (UserService에서 활성 직원 목록 가져와야 함)
+        
+        log.info("모든 직원 연차 초기화 및 재부여 완료");
+    }
+    
+
+    
+    // Helper methods
+    
+    private EmployeeLeaveBalanceResponseDto convertToResponseDto(EmployeeLeaveBalance balance) {
+        return EmployeeLeaveBalanceResponseDto.builder()
+                .id(balance.getId())
+                .employeeId(balance.getEmployeeId())
+                .leaveType(balance.getLeaveType())
+                .leaveTypeName(getLeaveTypeName(balance.getLeaveType()))
+                .totalLeaveDays(balance.getTotalLeaveDays())
+                .usedLeaveDays(balance.getUsedLeaveDays())
+                .remainingDays(balance.getRemainingDays())
+                .workYears(balance.getWorkYears())
+                .usageRate(balance.getUsageRate())
+                .createdAt(balance.getCreatedAt())
+                .updatedAt(balance.getUpdatedAt())
+                .build();
+    }
+    
+    private String getLeaveTypeName(LeaveType leaveType) {
+        switch (leaveType) {
+            case BASIC_ANNUAL: return "기본 연차";
+            case COMPENSATION_ANNUAL: return "보상 연차";
+            case SPECIAL_ANNUAL: return "특별 연차";
+            default: return leaveType.name();
+        }
+    }
+    
+    private LeaveType mapToLeaveType(String annualLeaveName) {
+        // 연차 규정 이름을 LeaveType으로 매핑
+        if (annualLeaveName.contains("기본") || annualLeaveName.contains("일반")) {
+            return LeaveType.BASIC_ANNUAL;
+        } else if (annualLeaveName.contains("보상")) {
+            return LeaveType.COMPENSATION_ANNUAL;
+        } else if (annualLeaveName.contains("특별")) {
+            return LeaveType.SPECIAL_ANNUAL;
+        }
+        return LeaveType.BASIC_ANNUAL; // 기본값
+    }
+} 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/workschedule/WorkScheduleService.java
@@ -914,7 +914,7 @@ public class WorkScheduleService {
     public ColleagueScheduleResponseDto getColleagueSchedule(Long colleagueId, LocalDate startDate, LocalDate endDate) {
         try {
             // 1. 동료 정보 조회 (User Service에서)
-            Map<String, Object> colleagueInfo = userServiceClient.getUserById(colleagueId, null);
+            Map<String, Object> colleagueInfo = userServiceClient.getUserById(colleagueId);
             if (colleagueInfo == null) {
                 log.error("Colleague not found: {}", colleagueId);
                 return null;

--- a/attendance-service/src/main/resources/db/migration/V20250904__instant_utc_postgres.sql
+++ b/attendance-service/src/main/resources/db/migration/V20250904__instant_utc_postgres.sql
@@ -1,0 +1,31 @@
+-- PostgreSQL UTC migration: convert LocalDateTime-like columns to timestamptz assuming existing values are Asia/Seoul local times
+
+-- schedules
+ALTER TABLE schedules
+  ALTER COLUMN created_at TYPE timestamptz USING (created_at AT TIME ZONE 'Asia/Seoul'),
+  ALTER COLUMN updated_at TYPE timestamptz USING (updated_at AT TIME ZONE 'Asia/Seoul');
+
+-- work_policy
+ALTER TABLE work_policy
+  ALTER COLUMN created_at TYPE timestamptz USING (created_at AT TIME ZONE 'Asia/Seoul'),
+  ALTER COLUMN updated_at TYPE timestamptz USING (updated_at AT TIME ZONE 'Asia/Seoul');
+
+-- annual_leave
+ALTER TABLE annual_leave
+  ALTER COLUMN created_at TYPE timestamptz USING (created_at AT TIME ZONE 'Asia/Seoul'),
+  ALTER COLUMN updated_at TYPE timestamptz USING (updated_at AT TIME ZONE 'Asia/Seoul');
+
+-- work_time_adjustments
+ALTER TABLE work_time_adjustments
+  ALTER COLUMN created_at TYPE timestamptz USING (created_at AT TIME ZONE 'Asia/Seoul'),
+  ALTER COLUMN updated_at TYPE timestamptz USING (updated_at AT TIME ZONE 'Asia/Seoul');
+
+-- leave_requests
+ALTER TABLE leave_requests
+  ALTER COLUMN requested_at TYPE timestamptz USING (requested_at AT TIME ZONE 'Asia/Seoul'),
+  ALTER COLUMN approved_at  TYPE timestamptz USING (approved_at  AT TIME ZONE 'Asia/Seoul');
+
+-- attendance (only if stored as local datetime previously)
+-- ALTER TABLE attendance
+--   ALTER COLUMN check_in  TYPE timestamptz USING (check_in  AT TIME ZONE 'Asia/Seoul'),
+--   ALTER COLUMN check_out TYPE timestamptz USING (check_out AT TIME ZONE 'Asia/Seoul'); 


### PR DESCRIPTION
## 이슈 번호

close #135 

## 작업 사항
feat(attendance-service): 연차 잔액 관리/연차 부여 로직 구현 및 연동 개선 연차 자동 부여(grant-annual), 초기화 및 재부여(reset), 전체 재부여(reset-all) 로직 구현 연차 사용/복구(use/restore) 시 잔액 차감/복구 처리 및 검증 로직 추가
직원 연차 잔액 상세/요약/잔여 조회 API 정리
UserService 연동: /api/users/{userId} 기반으로 근무정책/근무년수 참조 Feign Authorization 자동 전달 설정 추가 및 호출 시그니처 통합
Swagger 문서화 보강(Tag/Operation/Schema)

## 스크린샷 (선택)


## 공유사항
user-service에서 workpolicy와 근무 년수 정보를 가져와야 작동
실제로는 workpolicy 정보밖에 가져오지 못함 (근무 년수 정보가 없으면 1년으로 임시 지정)























