### PR TITLE
LazyInitializationException 해결을 위한 UserResponseDto 리팩토링

### DIFF
--- a/user-service/src/main/java/com/hermes/userservice/dto/JobDto.java
+++ b/user-service/src/main/java/com/hermes/userservice/dto/JobDto.java
@@ -1,0 +1,22 @@
+package com.hermes.userservice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "직무 응답 DTO")
+public class JobDto {
+    
+    @Schema(description = "직무 ID")
+    private Long id;
+    
+    @Schema(description = "직무명")
+    private String name;
+    
+    @Schema(description = "정렬 순서")
+    private Integer sortOrder;
+}

--- a/user-service/src/main/java/com/hermes/userservice/dto/PositionDto.java
+++ b/user-service/src/main/java/com/hermes/userservice/dto/PositionDto.java
@@ -1,0 +1,22 @@
+package com.hermes.userservice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "직책 응답 DTO")
+public class PositionDto {
+    
+    @Schema(description = "직책 ID")
+    private Long id;
+    
+    @Schema(description = "직책명")
+    private String name;
+    
+    @Schema(description = "정렬 순서")
+    private Integer sortOrder;
+}

--- a/user-service/src/main/java/com/hermes/userservice/dto/RankDto.java
+++ b/user-service/src/main/java/com/hermes/userservice/dto/RankDto.java
@@ -1,0 +1,22 @@
+package com.hermes.userservice.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Schema(description = "직급 응답 DTO")
+public class RankDto {
+    
+    @Schema(description = "직급 ID")
+    private Long id;
+    
+    @Schema(description = "직급명")
+    private String name;
+    
+    @Schema(description = "정렬 순서")
+    private Integer sortOrder;
+}

--- a/user-service/src/main/java/com/hermes/userservice/dto/UserResponseDto.java
+++ b/user-service/src/main/java/com/hermes/userservice/dto/UserResponseDto.java
@@ -1,9 +1,6 @@
 package com.hermes.userservice.dto;
 
 import com.hermes.userservice.entity.EmploymentType;
-import com.hermes.userservice.entity.Job;
-import com.hermes.userservice.entity.Position;
-import com.hermes.userservice.entity.Rank;
 import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
@@ -28,9 +25,9 @@ public class UserResponseDto {
     private Boolean isAdmin;
     private Boolean needsPasswordReset;
     private EmploymentType employmentType;
-    private Rank rank;
-    private Position position;
-    private Job job;
+    private RankDto rank;
+    private PositionDto position;
+    private JobDto job;
     private String role;
     private String profileImageUrl;
     private String selfIntroduction;

--- a/user-service/src/main/java/com/hermes/userservice/mapper/UserMapper.java
+++ b/user-service/src/main/java/com/hermes/userservice/mapper/UserMapper.java
@@ -96,9 +96,9 @@ public class UserMapper {
                 .isAdmin(user.getIsAdmin())
                 .needsPasswordReset(user.getNeedsPasswordReset())
                 .employmentType(user.getEmploymentType())
-                .rank(user.getRank())
-                .position(user.getPosition())
-                .job(user.getJob())
+                .rank(toRankDto(user.getRank()))
+                .position(toPositionDto(user.getPosition()))
+                .job(toJobDto(user.getJob()))
                 .role(user.getRole())
                 .profileImageUrl(user.getProfileImageUrl())
                 .selfIntroduction(user.getSelfIntroduction())
@@ -131,6 +131,39 @@ public class UserMapper {
                 .isLeader((Boolean) remoteData.get("isLeader"))
                 .assignedAt(remoteData.get("assignedAt") != null ? 
                         java.time.LocalDateTime.parse((String) remoteData.get("assignedAt")) : null)
+                .build();
+    }
+    
+    private RankDto toRankDto(com.hermes.userservice.entity.Rank rank) {
+        if (rank == null) {
+            return null;
+        }
+        return RankDto.builder()
+                .id(rank.getId())
+                .name(rank.getName())
+                .sortOrder(rank.getSortOrder())
+                .build();
+    }
+    
+    private JobDto toJobDto(com.hermes.userservice.entity.Job job) {
+        if (job == null) {
+            return null;
+        }
+        return JobDto.builder()
+                .id(job.getId())
+                .name(job.getName())
+                .sortOrder(job.getSortOrder())
+                .build();
+    }
+    
+    private PositionDto toPositionDto(com.hermes.userservice.entity.Position position) {
+        if (position == null) {
+            return null;
+        }
+        return PositionDto.builder()
+                .id(position.getId())
+                .name(position.getName())
+                .sortOrder(position.getSortOrder())
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- UserResponseDto에서 Rank, Job, Position 엔티티를 각각 RankDto, JobDto, PositionDto로 분리
- UserMapper에 엔티티-DTO 변환 로직 추가하여 트랜잭션 범위 외에서 발생하는 LazyInitializationException 문제 해결
- JSON 응답 구조는 동일하므로 클라이언트 변경 불필요

## 문제 상황
UserService.getAllUsers()에서 `@Transactional(readOnly = true)` 환경에서:
1. User 엔티티의 rank, job, position이 `@ManyToOne(fetch = FetchType.LAZY)`로 설정
2. userRepository.findAll()이 연관 엔티티를 즉시 로드하지 않음
3. UserMapper에서 user.getRank() 호출 시 프록시 초기화 시도
4. 트랜잭션이 끝난 후 DTO 변환 과정에서 LazyInitializationException 발생

이런 이유로 응답에는 Entity를 직접 사용하면 안됩니다

## 해결 방안
1. **DTO 분리**: Rank, Job, Position 엔티티를 각각의 DTO로 분리
2. **변환 로직**: UserMapper에 null-safe 엔티티-DTO 변환 메서드 추가
3. **계층 분리**: 엔티티와 DTO 계층을 명확히 분리하여 순환 참조 위험 제거

## API 호환성
- **기존 API 구조 완전 유지**: JSON 응답 구조가 동일하게 유지됨
- **클라이언트 영향 없음**: 프론트엔드나 다른 서비스에서 API 변경 불필요  
- **백엔드 내부 구조만 개선**: 엔티티-DTO 변환 로직만 개선되어 외부 인터페이스는 그대로
