### PR TITLE
feat: 근무년수 자동 계산 및 연차 정책 적용 기능 구현

### DIFF
--- a/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
@@ -14,4 +14,10 @@ public interface UserServiceClient {
     
     @GetMapping("/api/users/count")
     Map<String, Object> getTotalEmployees();
+    
+    /**
+     * 사용자의 근무년수 조회
+     */
+    @GetMapping("/api/users/{userId}/work-years")
+    Map<String, Integer> getUserWorkYears(@PathVariable("userId") Long userId);
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/EmployeeLeaveBalanceController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/EmployeeLeaveBalanceController.java
@@ -154,4 +154,33 @@ public class EmployeeLeaveBalanceController {
         employeeLeaveBalanceService.resetAllEmployeesAnnualLeave(newGrantDate);
         return ResponseEntity.ok(ApiResult.success("모든 직원의 연차 초기화 및 재부여가 완료되었습니다."));
     }
+    
+    @Operation(summary = "근무년수 기반 연차 부여", description = "user-service에서 조회한 근무년수를 기반으로 직원에게 연차를 부여합니다.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "연차 부여 성공"),
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 (직원 정보 없음, 근무정책 없음 등)")
+    })
+    @PostMapping("/grant-by-work-years/{employeeId}")
+    public ResponseEntity<ApiResult<List<EmployeeLeaveBalanceResponseDto>>> grantAnnualLeaveByWorkYears(
+            @Parameter(description = "직원 ID", required = true) @PathVariable Long employeeId) {
+        
+        log.info("근무년수 기반 연차 부여 요청: employeeId={}", employeeId);
+        
+        List<EmployeeLeaveBalanceResponseDto> responses = employeeLeaveBalanceService.grantAnnualLeaveByWorkYears(employeeId);
+        return ResponseEntity.ok(ApiResult.success(responses));
+    }
+    
+    @Operation(summary = "모든 직원 근무년수 기반 연차 부여", description = "모든 직원에게 각각의 근무년수에 따라 연차를 부여합니다. (관리자 전용)")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "전체 연차 부여 성공"),
+        @ApiResponse(responseCode = "500", description = "서버 오류")
+    })
+    @PostMapping("/grant-all-by-work-years")
+    public ResponseEntity<ApiResult<String>> grantAnnualLeaveToAllEmployees() {
+        
+        log.info("모든 직원 근무년수 기반 연차 부여 요청");
+        
+        employeeLeaveBalanceService.grantAnnualLeaveToAllEmployees();
+        return ResponseEntity.ok(ApiResult.success("모든 직원에게 근무년수 기반 연차 부여가 완료되었습니다."));
+    }
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/service/leave/EmployeeLeaveBalanceService.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/service/leave/EmployeeLeaveBalanceService.java
@@ -15,6 +15,16 @@ public interface EmployeeLeaveBalanceService {
     List<EmployeeLeaveBalanceResponseDto> grantAnnualLeave(Long employeeId, LocalDate baseDate);
     
     /**
+     * 직원의 근무년수 기반 연차 자동 부여 (workYears 직접 사용)
+     */
+    List<EmployeeLeaveBalanceResponseDto> grantAnnualLeaveByWorkYears(Long employeeId);
+    
+    /**
+     * 모든 직원에게 근무년수 기반 연차 부여
+     */
+    void grantAnnualLeaveToAllEmployees();
+    
+    /**
      * 연차 사용 (차감)
      */
     void useLeave(Long employeeId, LeaveType leaveType, Integer days);

--- a/user-service/src/main/java/com/hermes/userservice/dto/UserResponseDto.java
+++ b/user-service/src/main/java/com/hermes/userservice/dto/UserResponseDto.java
@@ -40,6 +40,7 @@ public class UserResponseDto {
     private String profileImageUrl;
     private String selfIntroduction;
     private Long workPolicyId;
+    private Integer workYears;
     private LocalDateTime lastLoginAt;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;

--- a/user-service/src/main/java/com/hermes/userservice/entity/User.java
+++ b/user-service/src/main/java/com/hermes/userservice/entity/User.java
@@ -42,6 +42,9 @@ public class User {
     @Column(nullable = false)
     private LocalDate joinDate;
 
+    @Column(name = "work_years")
+    private Integer workYears;
+
     @Column(nullable = false)
     private Boolean isAdmin;
 
@@ -103,6 +106,12 @@ public class User {
         log.info("updateJoinDate 호출: joinDate={}", joinDate);
         this.joinDate = joinDate;
         log.info("updateJoinDate 완료: this.joinDate={}", this.joinDate);
+    }
+
+    public void updateWorkYears(Integer workYears) {
+        log.info("updateWorkYears 호출: workYears={}", workYears);
+        this.workYears = workYears;
+        log.info("updateWorkYears 완료: this.workYears={}", this.workYears);
     }
 
     public void updateWorkInfo(EmploymentType employmentType, Rank rank, Position position, Job job, String role, Long workPolicyId) {

--- a/user-service/src/main/java/com/hermes/userservice/mapper/UserMapper.java
+++ b/user-service/src/main/java/com/hermes/userservice/mapper/UserMapper.java
@@ -6,6 +6,7 @@ import com.hermes.userservice.dto.workpolicy.WorkPolicyResponseDto;
 import com.hermes.userservice.entity.User;
 import com.hermes.userservice.entity.UserOrganization;
 import com.hermes.userservice.repository.*;
+import com.hermes.userservice.util.CareerCalculator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
@@ -27,13 +28,17 @@ public class UserMapper {
     private final JobRepository jobRepository;
 
     public User toEntity(UserCreateDto userCreateDto) {
+        LocalDate joinDate = Optional.ofNullable(userCreateDto.getJoinDate()).orElse(LocalDate.now());
+        int workYears = CareerCalculator.calculateCareerYears(joinDate);
+        
         return User.builder()
                 .name(userCreateDto.getName())
                 .email(userCreateDto.getEmail())
                 .password(passwordEncoder.encode(userCreateDto.getPassword()))
                 .phone(userCreateDto.getPhone())
                 .address(userCreateDto.getAddress())
-                .joinDate(Optional.ofNullable(userCreateDto.getJoinDate()).orElse(LocalDate.now()))
+                .joinDate(joinDate)
+                .workYears(workYears)
                 .isAdmin(Optional.ofNullable(userCreateDto.getIsAdmin()).orElse(false))
                 .needsPasswordReset(Optional.ofNullable(userCreateDto.getNeedsPasswordReset()).orElse(false))
                 .employmentType(convertToEmploymentTypeEntity(userCreateDto.getEmploymentType()))
@@ -115,6 +120,7 @@ public class UserMapper {
                 .profileImageUrl(user.getProfileImageUrl())
                 .selfIntroduction(user.getSelfIntroduction())
                 .workPolicyId(user.getWorkPolicyId())
+                .workYears(user.getWorkYears())
                 .lastLoginAt(user.getLastLoginAt())
                 .createdAt(user.getCreatedAt())
                 .updatedAt(user.getUpdatedAt())

--- a/user-service/src/main/java/com/hermes/userservice/repository/UserRepository.java
+++ b/user-service/src/main/java/com/hermes/userservice/repository/UserRepository.java
@@ -40,4 +40,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
     @Modifying
     @Query("UPDATE User u SET u.profileImageUrl = :profileImageUrl WHERE u.id = :userId")
     void updateProfileImageUrl(@Param("userId") Long userId, @Param("profileImageUrl") String profileImageUrl);
+    
+    /**
+     * workYears가 null인 사용자 목록 조회
+     */
+    List<User> findByWorkYearsIsNull();
 }

--- a/user-service/src/main/java/com/hermes/userservice/scheduler/VacationScheduler.java
+++ b/user-service/src/main/java/com/hermes/userservice/scheduler/VacationScheduler.java
@@ -1,6 +1,7 @@
 package com.hermes.userservice.scheduler;
 
 import com.hermes.userservice.service.VacationService;
+import com.hermes.userservice.service.UserService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Component;
 public class VacationScheduler {
 
     private final VacationService vacationService;
+    private final UserService userService;
 
     @Scheduled(cron = "0 0 0 * * ?", zone = "Asia/Seoul")
     public void grantVacationOnAnniversaries() {
@@ -22,6 +24,22 @@ public class VacationScheduler {
             log.info("연차 부여 스케줄러 실행 완료: {}명에게 연차 부여", grantedCount);
         } catch (Exception e) {
             log.error("연차 부여 스케줄러 실행 실패", e);
+        }
+    }
+
+    /**
+     * 매일 자정에 모든 사용자의 근무년수를 업데이트
+     * 연차 부여와 함께 근무년수도 최신 상태로 유지
+     */
+    @Scheduled(cron = "0 5 0 * * ?", zone = "Asia/Seoul") // 자정 5분 후 실행 (연차 부여 후)
+    public void updateAllUsersWorkYears() {
+        log.info("전체 사용자 근무년수 자동 업데이트 시작");
+        
+        try {
+            userService.updateAllUsersWorkYears();
+            log.info("전체 사용자 근무년수 자동 업데이트 완료");
+        } catch (Exception e) {
+            log.error("전체 사용자 근무년수 자동 업데이트 실패", e);
         }
     }
 }

--- a/user-service/src/main/java/com/hermes/userservice/service/UserService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/UserService.java
@@ -12,8 +12,11 @@ import com.hermes.userservice.exception.DuplicateEmailException;
 import com.hermes.userservice.exception.UserNotFoundException;
 import com.hermes.userservice.mapper.UserMapper;
 import com.hermes.userservice.repository.*;
+import com.hermes.userservice.util.CareerCalculator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -29,7 +32,7 @@ import java.util.stream.Collectors;
 @Service
 @RequiredArgsConstructor
 @Transactional
-public class UserService {
+public class UserService implements ApplicationRunner {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
@@ -40,6 +43,25 @@ public class UserService {
     private final RankRepository rankRepository;
     private final PositionRepository positionRepository;
     private final JobRepository jobRepository;
+
+    @Override
+    public void run(ApplicationArguments args) throws Exception {
+        log.info("애플리케이션 시작 시 근무년수가 null인 사용자들을 초기화합니다.");
+        List<User> usersWithNullWorkYears = userRepository.findByWorkYearsIsNull();
+        int initializedCount = 0;
+        for (User user : usersWithNullWorkYears) {
+            try {
+                int workYears = CareerCalculator.calculateCareerYears(user.getJoinDate());
+                user.updateWorkYears(workYears);
+                userRepository.save(user);
+                initializedCount++;
+                log.debug("근무년수 초기화: userId={}, workYears={}", user.getId(), workYears);
+            } catch (Exception e) {
+                log.error("사용자 근무년수 초기화 실패: userId={}", user.getId(), e);
+            }
+        }
+        log.info("애플리케이션 시작 시 근무년수 초기화 완료: 총 {}명 초기화", initializedCount);
+    }
 
     @Transactional(readOnly = true)
     public UserResponseDto getUserById(Long userId) {
@@ -348,5 +370,84 @@ public class UserService {
         userRepository.updateProfileImageUrl(userId, profileImageUrl);
 
         log.info("프로필 이미지 업데이트 완료: userId={}", userId);
+    }
+
+    /**
+     * 특정 사용자의 근무년수를 계산하여 업데이트
+     */
+    public void updateWorkYears(Long userId) {
+        log.info("근무년수 업데이트 시작: userId={}", userId);
+        
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다: " + userId));
+        
+        int workYears = CareerCalculator.calculateCareerYears(user.getJoinDate());
+        user.updateWorkYears(workYears);
+        
+        userRepository.save(user);
+        
+        log.info("근무년수 업데이트 완료: userId={}, workYears={}", userId, workYears);
+    }
+
+    /**
+     * 모든 사용자의 근무년수를 계산하여 업데이트
+     */
+    public void updateAllUsersWorkYears() {
+        log.info("전체 사용자 근무년수 업데이트 시작");
+        
+        List<User> allUsers = userRepository.findAll();
+        int updatedCount = 0;
+        
+        for (User user : allUsers) {
+            try {
+                int workYears = CareerCalculator.calculateCareerYears(user.getJoinDate());
+                user.updateWorkYears(workYears);
+                userRepository.save(user);
+                updatedCount++;
+                log.debug("근무년수 업데이트: userId={}, workYears={}", user.getId(), workYears);
+            } catch (Exception e) {
+                log.error("사용자 근무년수 업데이트 실패: userId={}", user.getId(), e);
+            }
+        }
+        
+        log.info("전체 사용자 근무년수 업데이트 완료: 총 {}명 업데이트", updatedCount);
+    }
+
+    /**
+     * 사용자의 현재 근무년수 조회
+     */
+    @Transactional(readOnly = true)
+    public int getUserWorkYears(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new UserNotFoundException("사용자를 찾을 수 없습니다: " + userId));
+        
+        if (user.getWorkYears() != null) {
+            return user.getWorkYears();
+        }
+        
+        // workYears가 null인 경우 실시간 계산 후 저장
+        int calculatedWorkYears = CareerCalculator.calculateCareerYears(user.getJoinDate());
+        
+        // 별도 트랜잭션에서 업데이트 (readOnly 트랜잭션이므로)
+        updateWorkYearsAsync(userId, calculatedWorkYears);
+        
+        return calculatedWorkYears;
+    }
+    
+    /**
+     * 비동기적으로 workYears 업데이트 (내부 사용)
+     */
+    @Transactional
+    public void updateWorkYearsAsync(Long userId, int workYears) {
+        try {
+            User user = userRepository.findById(userId).orElse(null);
+            if (user != null && user.getWorkYears() == null) {
+                user.updateWorkYears(workYears);
+                userRepository.save(user);
+                log.info("workYears 자동 설정 완료: userId={}, workYears={}", userId, workYears);
+            }
+        } catch (Exception e) {
+            log.warn("workYears 자동 설정 실패: userId={}, workYears={}", userId, workYears, e);
+        }
     }
 }

--- a/user-service/src/main/java/com/hermes/userservice/service/VacationService.java
+++ b/user-service/src/main/java/com/hermes/userservice/service/VacationService.java
@@ -39,6 +39,12 @@ public class VacationService {
         }
         
         int careerYears = CareerCalculator.calculateCareerYears(joinDate);
+        
+        // 근무년수 업데이트 (연차 부여와 함께)
+        user.updateWorkYears(careerYears);
+        userRepository.save(user);
+        log.info("근무년수 업데이트 완료: userId={}, workYears={}", userId, careerYears);
+        
         int leaveDays = getLeaveDaysByCareerYears(user.getWorkPolicyId(), careerYears);
         
         if (leaveDays > 0) {


### PR DESCRIPTION
## 이슈 번호

close #

## 작업 사항
user-service
User 엔티티에 workYears 필드 추가 및 업데이트 로직 반영
CareerCalculator 연동: 사용자 생성 시 joinDate 기반 workYears 자동 계산 getUserWorkYears: workYears null 시 실시간 계산 후 비동기 저장 애플리케이션 시작 시 workYears가 null인 사용자 초기화 (ApplicationRunner) VacationScheduler: 매일 자정 연차 부여, 5분 후 전체 근무년수 업데이트 자동화 사용자 API에서 수동 트리거 엔드포인트 제거 및 관련 의존성 정리
attendance-service
UserServiceClient: workYears 조회 API 연동
EmployeeLeaveBalanceService: workYears 기반 연차 부여 로직 구현 grantAnnualLeaveByWorkYears/ToAllEmployees 엔드포인트 추가 WorkScheduleController: 근무 정책 스케줄 반영 API 정비

## 스크린샷 (선택)


## 공유사항























