### PR TITLE
feat(attendance-service): 사용자 근무정책 조회 개선 및 권한 정책 정비

### DIFF
--- a/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/client/UserServiceClient.java
@@ -14,4 +14,8 @@ public interface UserServiceClient {
     
     @GetMapping("/api/users/count")
     Map<String, Object> getTotalEmployees();
+
+    // 사용자의 근무정책 조회 (workPolicyId 또는 workPolicy 객체를 반환하는 사용자 서비스 엔드포인트)
+    @GetMapping("/api/users/{userId}/simple")
+    Map<String, Object> getUserWorkPolicy(@PathVariable("userId") Long userId);
 } 

--- a/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkScheduleController.java
+++ b/attendance-service/src/main/java/com/hermes/attendanceservice/controller/WorkScheduleController.java
@@ -46,14 +46,11 @@ public class WorkScheduleController {
         @ApiResponse(responseCode = "404", description = "근무 정책을 찾을 수 없음")
     })
     @GetMapping("/users/{userId}/work-policy")
+    @PreAuthorize("isAuthenticated()")
     public ResponseEntity<ApiResult<UserWorkPolicyDto>> getUserWorkPolicy(
             @Parameter(description = "사용자 ID") @PathVariable Long userId,
             @Parameter(description = "인증된 사용자 정보") @AuthenticationPrincipal UserPrincipal user) {
         try {
-            // 본인 또는 관리자만 조회 가능
-            if (!user.getId().equals(userId) && !user.getRole().name().equals("ADMIN")) {
-                return ResponseEntity.ok(ApiResult.failure("권한이 없습니다."));
-            }
             
             // Authorization 헤더는 null로 전달 (User Service에서 직접 처리)
             UserWorkPolicyDto result = workScheduleService.getUserWorkPolicy(userId);


### PR DESCRIPTION
## 이슈 번호

close #

## 작업 사항
UserServiceClient에 /api/users/{userId}/simple 추가
WorkScheduleService.getUserWorkPolicy에서 simple 우선 조회, 실패 시 /api/users/{userId} 폴백 응답에서 workPolicyId(top-level) 또는 workPolicy.id(nested) 모두 파싱 지원 WorkScheduleController#getUserWorkPolicy 권한을 isAuthenticated()로 완화 사용자 근무정책 조회 API: GET /api/work-schedule/users/{userId}/work-policy docs(attendance-service): 고정 스케줄/근무정책 적용 API 사용 가이드 보완 고정 스케줄 생성: POST /api/work-schedule/users/{userId}/fixed-schedules?startDate&endDate 근무정책 스케줄 적용: POST /api/work-schedule/users/{userId}/apply-work-policy?startDate&endDate

## 스크린샷 (선택)


## 공유사항























